### PR TITLE
Add roster functionality for SAMS teams

### DIFF
--- a/app/src/components/ImageGallery.tsx
+++ b/app/src/components/ImageGallery.tsx
@@ -16,7 +16,7 @@ export default function ImageGallery({ images }: { images?: string[] }) {
   if (!images || images.length === 0) return null;
 
   return (
-    <Group gap="xs" justify="center" preventGrowOverflow={false} mt="md">
+    <Group gap="xs" justify="flex-start" preventGrowOverflow={false} mt="md">
       {shuffledGallery.map((imageUrl: string, index) => {
         return (
           <AspectRatio

--- a/app/src/hooks/dataQueries.ts
+++ b/app/src/hooks/dataQueries.ts
@@ -18,6 +18,7 @@ import {
   getClubLogoUrlsBatchFn,
   getSamsMatchesFn,
   getSamsRankingByLeagueUuidFn,
+  getSamsRosterByTeamUuidFn,
   getSamsTickerFn,
   listSamsTeamsFn,
 } from "../server/functions/sams";
@@ -171,6 +172,14 @@ export const useSamsTeams = () => {
   return useQuery({
     queryKey: ["samsTeams"],
     queryFn: () => listSamsTeamsFn(),
+  });
+};
+
+export const useSamsRoster = (teamUuid?: string) => {
+  return useQuery({
+    queryKey: ["samsRoster", teamUuid],
+    queryFn: () => getSamsRosterByTeamUuidFn({ data: teamUuid as string }),
+    enabled: !!teamUuid,
   });
 };
 

--- a/app/src/routes/_layout/teams.$slug.tsx
+++ b/app/src/routes/_layout/teams.$slug.tsx
@@ -387,8 +387,8 @@ function TeamRoster({ teamUuid }: { teamUuid?: string }) {
         <CardTitle>Kader</CardTitle>
         {sortedPlayers.length > 0 && (
           <Flex wrap="wrap" gap="xl">
-            {sortedPlayers.map((player, index) => (
-              <Group key={player.uuid ?? `${player.name}-${index}`} align="center">
+            {sortedPlayers.map((player) => (
+              <Group key={player.uuid} align="center">
                 <Avatar src={player.portraitImageLink} name={player.name} />
                 <Stack gap={0}>
                   <Text fw="bold" c="turquoise">
@@ -409,8 +409,8 @@ function TeamRoster({ teamUuid }: { teamUuid?: string }) {
           <>
             <Text fw="bold">Offizielle</Text>
             <Flex wrap="wrap" gap="xl">
-              {roster.officials.map((official, index) => (
-                <Group key={official.uuid ?? `${official.name}-${index}`} align="center">
+              {roster.officials.map((official) => (
+                <Group key={official.uuid} align="center">
                   <Avatar name={official.name} />
                   <Stack gap={0}>
                     <Text fw="bold" c="turquoise">

--- a/app/src/routes/_layout/teams.$slug.tsx
+++ b/app/src/routes/_layout/teams.$slug.tsx
@@ -387,8 +387,8 @@ function TeamRoster({ teamUuid }: { teamUuid?: string }) {
         <CardTitle>Kader</CardTitle>
         {sortedPlayers.length > 0 && (
           <Flex wrap="wrap" gap="xl">
-            {sortedPlayers.map((player) => (
-              <Group key={player.uuid ?? player.name} align="center">
+            {sortedPlayers.map((player, index) => (
+              <Group key={player.uuid ?? `${player.name}-${index}`} align="center">
                 <Avatar src={player.portraitImageLink} name={player.name} />
                 <Stack gap={0}>
                   <Text fw="bold" c="turquoise">
@@ -409,8 +409,8 @@ function TeamRoster({ teamUuid }: { teamUuid?: string }) {
           <>
             <Text fw="bold">Offizielle</Text>
             <Flex wrap="wrap" gap="xl">
-              {roster.officials.map((official) => (
-                <Group key={official.uuid ?? official.name} align="center">
+              {roster.officials.map((official, index) => (
+                <Group key={official.uuid ?? `${official.name}-${index}`} align="center">
                   <Avatar name={official.name} />
                   <Stack gap={0}>
                     <Text fw="bold" c="turquoise">

--- a/app/src/routes/_layout/teams.$slug.tsx
+++ b/app/src/routes/_layout/teams.$slug.tsx
@@ -30,6 +30,7 @@ import {
   useLocations,
   useMembers,
   useSamsMatches,
+  useSamsRoster,
   useTeamBySlug,
 } from "@/app/src/hooks/dataQueries";
 import {
@@ -107,6 +108,9 @@ function RouteComponent() {
         </Suspense>
         <Suspense fallback={<CenteredLoader text="Lade Fotos..." />}>
           <TeamPictures team={team} />
+        </Suspense>
+        <Suspense fallback={null}>
+          <TeamRoster teamUuid={loaderData.samsTeam?.uuid} />
         </Suspense>
         <Suspense fallback={<CenteredLoader text="Lade Tabelle..." />}>
           {loaderData.samsTeam?.leagueUuid && (
@@ -362,6 +366,68 @@ function TeamTrainers({ team }: { team: NonNullable<ReturnType<typeof useTeamByS
           memberList={contacts}
         />
       </Flex>
+    </Card>
+  );
+}
+
+function TeamRoster({ teamUuid }: { teamUuid?: string }) {
+  const { data: roster } = useSamsRoster(teamUuid);
+
+  if (!roster || (!roster.players.length && !roster.officials.length)) return null;
+
+  const sortedPlayers = [...roster.players].sort((a, b) => {
+    if (a.jerseyNumber == null) return 1;
+    if (b.jerseyNumber == null) return -1;
+    return a.jerseyNumber - b.jerseyNumber;
+  });
+
+  return (
+    <Card>
+      <Stack>
+        <CardTitle>Kader</CardTitle>
+        {sortedPlayers.length > 0 && (
+          <Flex wrap="wrap" gap="xl">
+            {sortedPlayers.map((player) => (
+              <Group key={player.uuid ?? player.name} align="center">
+                <Avatar src={player.portraitImageLink} name={player.name} />
+                <Stack gap={0}>
+                  <Text fw="bold" c="turquoise">
+                    {player.jerseyNumber != null ? `#${player.jerseyNumber} ` : ""}
+                    {player.name}
+                  </Text>
+                  {player.position && (
+                    <Text c="dimmed" size="xs">
+                      {player.position}
+                    </Text>
+                  )}
+                </Stack>
+              </Group>
+            ))}
+          </Flex>
+        )}
+        {roster.officials.length > 0 && (
+          <>
+            <Text fw="bold">Offizielle</Text>
+            <Flex wrap="wrap" gap="xl">
+              {roster.officials.map((official) => (
+                <Group key={official.uuid ?? official.name} align="center">
+                  <Avatar name={official.name} />
+                  <Stack gap={0}>
+                    <Text fw="bold" c="turquoise">
+                      {official.name}
+                    </Text>
+                    {official.role && (
+                      <Text c="dimmed" size="xs">
+                        {official.role}
+                      </Text>
+                    )}
+                  </Stack>
+                </Group>
+              ))}
+            </Flex>
+          </>
+        )}
+      </Stack>
     </Card>
   );
 }

--- a/app/src/routes/_layout/teams.$slug.tsx
+++ b/app/src/routes/_layout/teams.$slug.tsx
@@ -1,12 +1,14 @@
 import {
   Anchor,
   Avatar,
+  Box,
   Button,
   Card,
   CardSection,
   Center,
   Flex,
   Group,
+  SimpleGrid,
   Stack,
   Text,
 } from "@mantine/core";
@@ -106,11 +108,11 @@ function RouteComponent() {
         <Suspense fallback={<CenteredLoader text="Lade Trainer..." />}>
           <TeamTrainers team={team} />
         </Suspense>
-        <Suspense fallback={<CenteredLoader text="Lade Fotos..." />}>
-          <TeamPictures team={team} />
-        </Suspense>
         <Suspense fallback={null}>
           <TeamRoster teamUuid={loaderData.samsTeam?.uuid} />
+        </Suspense>
+        <Suspense fallback={<CenteredLoader text="Lade Fotos..." />}>
+          <TeamPictures team={team} />
         </Suspense>
         <Suspense fallback={<CenteredLoader text="Lade Tabelle..." />}>
           {loaderData.samsTeam?.leagueUuid && (
@@ -370,62 +372,141 @@ function TeamTrainers({ team }: { team: NonNullable<ReturnType<typeof useTeamByS
   );
 }
 
+/** SAMS often returns "Nachname, Vorname" — prefer "Vorname Nachname" for display. */
+function parseRosterName(name: string): { first: string; last: string; display: string } {
+  const comma = name.indexOf(",");
+  if (comma === -1) {
+    const trimmed = name.trim();
+    return { first: trimmed, last: "", display: trimmed };
+  }
+  const last = name.slice(0, comma).trim();
+  const first = name.slice(comma + 1).trim();
+  if (!last || !first) {
+    const trimmed = name.trim();
+    return { first: trimmed, last: "", display: trimmed };
+  }
+  return { first, last, display: `${first} ${last}` };
+}
+
+function formatRosterName(name: string): string {
+  return parseRosterName(name).display;
+}
+
+function compareRosterPlayers(
+  a: { jerseyNumber?: number; name: string },
+  b: { jerseyNumber?: number; name: string },
+): number {
+  if (a.jerseyNumber != null && b.jerseyNumber != null && a.jerseyNumber !== b.jerseyNumber) {
+    return a.jerseyNumber - b.jerseyNumber;
+  }
+  if ((a.jerseyNumber != null) !== (b.jerseyNumber != null)) {
+    return a.jerseyNumber != null ? -1 : 1;
+  }
+  return parseRosterName(a.name).first.localeCompare(parseRosterName(b.name).first, "de");
+}
+
+function JerseyNumber({ number }: { number?: number }) {
+  const hasNumber = number != null;
+  return (
+    <Box
+      w={48}
+      h={48}
+      style={{
+        flexShrink: 0,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        borderRadius: "50%",
+        background: hasNumber
+          ? "var(--mantine-color-blumine-6)"
+          : "var(--mantine-color-aquahaze-2)",
+        color: hasNumber ? "white" : "var(--mantine-color-dimmed)",
+        fontWeight: 800,
+        fontSize: hasNumber ? (number >= 10 ? "1.1rem" : "1.35rem") : "1rem",
+        letterSpacing: hasNumber ? "-0.02em" : undefined,
+        fontVariantNumeric: "tabular-nums",
+        lineHeight: 1,
+      }}
+      aria-label={hasNumber ? `Trikotnummer ${number}` : "Keine Trikotnummer"}
+    >
+      {hasNumber ? number : "–"}
+    </Box>
+  );
+}
+
 function TeamRoster({ teamUuid }: { teamUuid?: string }) {
   const { data: roster } = useSamsRoster(teamUuid);
 
-  if (!roster || (!roster.players.length && !roster.officials.length)) return null;
+  if (!roster) return null;
 
-  const sortedPlayers = [...roster.players].sort((a, b) => {
-    if (a.jerseyNumber == null) return 1;
-    if (b.jerseyNumber == null) return -1;
-    return a.jerseyNumber - b.jerseyNumber;
-  });
+  const sortedPlayers = [...roster.players].sort(compareRosterPlayers);
+  const officialsWithRole = roster.officials.filter((official) => !!official.role?.trim());
 
+  if (!sortedPlayers.length && !officialsWithRole.length) return null;
   return (
     <Card>
-      <Stack>
+      <Stack gap="lg">
         <CardTitle>Kader</CardTitle>
         {sortedPlayers.length > 0 && (
-          <Flex wrap="wrap" gap="xl">
+          <SimpleGrid cols={{ base: 1, xs: 2, sm: 3, md: 4 }} spacing="md">
             {sortedPlayers.map((player) => (
-              <Group key={player.uuid} align="center">
-                <Avatar src={player.portraitImageLink} name={player.name} />
-                <Stack gap={0}>
-                  <Text fw="bold" c="turquoise">
-                    {player.jerseyNumber != null ? `#${player.jerseyNumber} ` : ""}
-                    {player.name}
+              <Group key={player.uuid} gap="sm" wrap="nowrap" align="center">
+                {player.portraitImageLink ? (
+                  <Avatar src={player.portraitImageLink} name={player.name} size={48} radius="xl" />
+                ) : (
+                  <JerseyNumber number={player.jerseyNumber} />
+                )}
+                <Stack gap={2} style={{ minWidth: 0 }}>
+                  {player.portraitImageLink && player.jerseyNumber != null && (
+                    <Text
+                      size="xs"
+                      fw={700}
+                      c="blumine"
+                      tt="uppercase"
+                      style={{ letterSpacing: "0.04em" }}
+                    >
+                      Nr. {player.jerseyNumber}
+                    </Text>
+                  )}
+                  <Text fw={700} c="blumine" truncate>
+                    {formatRosterName(player.name)}
                   </Text>
                   {player.position && (
-                    <Text c="dimmed" size="xs">
+                    <Text c="dimmed" size="xs" truncate>
                       {player.position}
                     </Text>
                   )}
                 </Stack>
               </Group>
             ))}
-          </Flex>
+          </SimpleGrid>
         )}
-        {roster.officials.length > 0 && (
-          <>
-            <Text fw="bold">Offizielle</Text>
-            <Flex wrap="wrap" gap="xl">
-              {roster.officials.map((official) => (
-                <Group key={official.uuid} align="center">
-                  <Avatar name={official.name} />
-                  <Stack gap={0}>
-                    <Text fw="bold" c="turquoise">
-                      {official.name}
+        {officialsWithRole.length > 0 && (
+          <Stack gap="sm">
+            <Text fw={700} size="sm" c="dimmed" tt="uppercase" style={{ letterSpacing: "0.06em" }}>
+              Offizielle
+            </Text>
+            <SimpleGrid cols={{ base: 1, xs: 2, sm: 3 }} spacing="md">
+              {officialsWithRole.map((official) => (
+                <Group key={official.uuid} gap="sm" wrap="nowrap" align="center">
+                  <Avatar
+                    name={formatRosterName(official.name)}
+                    size={40}
+                    radius="xl"
+                    color="blumine"
+                  />
+                  <Stack gap={2} style={{ minWidth: 0 }}>
+                    <Text fw={700} c="blumine" truncate>
+                      {formatRosterName(official.name)}
                     </Text>
-                    {official.role && (
-                      <Text c="dimmed" size="xs">
-                        {official.role}
-                      </Text>
-                    )}
+                    <Text c="dimmed" size="xs" truncate>
+                      {official.role}
+                    </Text>
                   </Stack>
                 </Group>
               ))}
-            </Flex>
-          </>
+            </SimpleGrid>
+          </Stack>
         )}
       </Stack>
     </Card>

--- a/app/src/server/functions/sams.server.ts
+++ b/app/src/server/functions/sams.server.ts
@@ -32,6 +32,7 @@ import {
   getSamsClubByNameSlug,
   getSamsClubByNameSlugPrefix,
   getSamsClubBySportsclubUuid,
+  getSamsRosterByTeamUuid,
 } from "../queries";
 import { readCacheEntry, writeCacheEntry } from "../ddb-cache";
 import { parseServerData } from "../schema-parse";
@@ -417,6 +418,10 @@ export async function handleListSamsTeams() {
     teams: result.items,
     lastEvaluatedKey: result.lastEvaluatedKey,
   };
+}
+
+export async function handleGetSamsRosterByTeamUuid(teamUuid: string) {
+  return getSamsRosterByTeamUuid(teamUuid);
 }
 
 type ClubLogoInput =

--- a/app/src/server/functions/sams.ts
+++ b/app/src/server/functions/sams.ts
@@ -15,6 +15,7 @@ import {
   handleGetSamsMatches,
   handleGetSamsRankingByLeagueUuid,
   handleGetSamsRankingsByLeagueUuids,
+  handleGetSamsRosterByTeamUuid,
   handleGetSamsTicker,
   handleListSamsClubs,
   handleListSamsTeams,
@@ -63,6 +64,10 @@ export const peekSamsMatchesCacheFn = createServerFn()
 export const listSamsClubsFn = createServerFn().handler(async () => handleListSamsClubs());
 
 export const listSamsTeamsFn = createServerFn().handler(async () => handleListSamsTeams());
+
+export const getSamsRosterByTeamUuidFn = createServerFn()
+  .validator(z.string().min(1))
+  .handler(async ({ data: teamUuid }) => handleGetSamsRosterByTeamUuid(teamUuid));
 
 export const getClubLogoUrlFn = createServerFn()
   .validator(clubLogoInputSchema)

--- a/app/src/server/queries.test.ts
+++ b/app/src/server/queries.test.ts
@@ -13,6 +13,7 @@ let getSamsClubBySportsclubUuid: typeof import("./queries").getSamsClubBySportsc
 let getSamsClubByNameSlug: typeof import("./queries").getSamsClubByNameSlug;
 let getAllSamsTeams: typeof import("./queries").getAllSamsTeams;
 let getSamsTeamByUuid: typeof import("./queries").getSamsTeamByUuid;
+let getSamsRosterByTeamUuid: typeof import("./queries").getSamsRosterByTeamUuid;
 
 describe("server/queries", () => {
   beforeAll(async () => {
@@ -28,6 +29,7 @@ describe("server/queries", () => {
     getSamsClubByNameSlug = q.getSamsClubByNameSlug;
     getAllSamsTeams = q.getAllSamsTeams;
     getSamsTeamByUuid = q.getSamsTeamByUuid;
+    getSamsRosterByTeamUuid = q.getSamsRosterByTeamUuid;
   });
 
   beforeEach(() => {
@@ -306,6 +308,37 @@ describe("server/queries", () => {
     it("returns null when not found", async () => {
       ddbMock.on(GetCommand).resolves({ Item: undefined });
       const result = await getSamsTeamByUuid("missing");
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("getSamsRosterByTeamUuid", () => {
+    it("gets roster by teamUuid primary key via ElectroDB", async () => {
+      const mockRoster = {
+        teamUuid: "t1",
+        type: "roster",
+        players: [{ uuid: "p1", name: "Jane Doe", jerseyNumber: 7, position: "Zuspiel" }],
+        officials: [{ uuid: "o1", name: "Coach Smith", role: "Trainer" }],
+        updatedAt: "2024-01-01T00:00:00Z",
+        ttl: 123,
+        __edb_e__: "samsroster",
+        __edb_v__: "1",
+      };
+      ddbMock.on(GetCommand).resolves({ Item: mockRoster });
+
+      const result = await getSamsRosterByTeamUuid("t1");
+
+      expect(result).not.toBeNull();
+      expect(result?.teamUuid).toBe("t1");
+      expect(result?.players).toHaveLength(1);
+      expect(result?.officials).toHaveLength(1);
+      const calls = ddbMock.commandCalls(GetCommand);
+      expect(calls[0].args[0].input.TableName).toBe("test-sams-table");
+    });
+
+    it("returns null when not found", async () => {
+      ddbMock.on(GetCommand).resolves({ Item: undefined });
+      const result = await getSamsRosterByTeamUuid("missing");
       expect(result).toBeNull();
     });
   });

--- a/app/src/server/queries.ts
+++ b/app/src/server/queries.ts
@@ -1,6 +1,8 @@
 import {
   type ClubResponse,
   ClubResponseSchema,
+  type RosterResponse,
+  RosterResponseSchema,
   type TeamResponse,
   TeamResponseSchema,
 } from "@/lambda/sams/types";
@@ -106,4 +108,9 @@ export async function getAllSamsTeams(): Promise<PaginatedResult<TeamResponse>> 
 export async function getSamsTeamByUuid(uuid: string): Promise<TeamResponse | null> {
   const result = await samsDb().team.get({ uuid }).go();
   return result.data ? TeamResponseSchema.parse(result.data) : null;
+}
+
+export async function getSamsRosterByTeamUuid(teamUuid: string): Promise<RosterResponse | null> {
+  const result = await samsDb().roster.get({ teamUuid }).go();
+  return result.data ? RosterResponseSchema.parse(result.data) : null;
 }

--- a/codegen/sams/generate-client.ts
+++ b/codegen/sams/generate-client.ts
@@ -216,6 +216,41 @@ createClient({
             }
           }
         },
+        // SAMS returns null (not omitted) for unset optional player/official fields.
+        // Without nullable:true, responseValidator rejects the roster and teams-sync
+        // silently skips writing (data=undefined, error set, no throw).
+        TeamPlayerDto: (schema) => {
+          if (schema.properties) {
+            for (const [key, property] of Object.entries(schema.properties)) {
+              if (typeof property === "object" && property !== null) {
+                switch (key) {
+                  case "uuid":
+                  case "name":
+                    property.nullable = false;
+                    break;
+                  default:
+                    property.nullable = true;
+                }
+              }
+            }
+          }
+        },
+        TeamOfficialDto: (schema) => {
+          if (schema.properties) {
+            for (const [key, property] of Object.entries(schema.properties)) {
+              if (typeof property === "object" && property !== null) {
+                switch (key) {
+                  case "uuid":
+                  case "name":
+                    property.nullable = false;
+                    break;
+                  default:
+                    property.nullable = true;
+                }
+              }
+            }
+          }
+        },
         SportsclubDto: (schema) => {
           if (schema.properties) {
             schema.required = ["uuid", "name"];

--- a/codegen/sams/generated/source.json
+++ b/codegen/sams/generated/source.json
@@ -5878,11 +5878,11 @@
             "type": "string",
             "nullable": true
           },
-          "delayPossible": {
+          "indefinitelyRescheduled": {
             "type": "boolean",
             "nullable": true
           },
-          "indefinitelyRescheduled": {
+          "delayPossible": {
             "type": "boolean",
             "nullable": true
           }
@@ -6296,11 +6296,11 @@
             "type": "string",
             "nullable": true
           },
-          "delayPossible": {
+          "indefinitelyRescheduled": {
             "type": "boolean",
             "nullable": true
           },
-          "indefinitelyRescheduled": {
+          "delayPossible": {
             "type": "boolean",
             "nullable": true
           }
@@ -6548,23 +6548,29 @@
         "type": "object",
         "properties": {
           "uuid": {
-            "type": "string"
+            "type": "string",
+            "nullable": false
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "nullable": false
           },
           "birthdate": {
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           "nationality": {
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           "portraitImageLink": {
             "type": "string",
-            "format": "url"
+            "format": "url",
+            "nullable": true
           },
           "role": {
-            "type": "string"
+            "type": "string",
+            "nullable": true
           }
         }
       },
@@ -6572,31 +6578,39 @@
         "type": "object",
         "properties": {
           "uuid": {
-            "type": "string"
+            "type": "string",
+            "nullable": false
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "nullable": false
           },
           "birthdate": {
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           "nationality": {
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           "portraitImageLink": {
             "type": "string",
-            "format": "url"
+            "format": "url",
+            "nullable": true
           },
           "height": {
             "type": "integer",
-            "format": "int32"
+            "format": "int32",
+            "nullable": true
           },
           "jerseyNumber": {
             "type": "integer",
-            "format": "int32"
+            "format": "int32",
+            "nullable": true
           },
           "position": {
-            "type": "string"
+            "type": "string",
+            "nullable": true
           }
         }
       },

--- a/codegen/sams/generated/types.gen.ts
+++ b/codegen/sams/generated/types.gen.ts
@@ -601,8 +601,8 @@ export type CompetitionMatchDto = {
   team2Mvp?: MostValuablePlayerDto;
   matchGroupUuid?: string | null;
   competitionUuid?: string | null;
-  delayPossible?: boolean | null;
   indefinitelyRescheduled?: boolean | null;
+  delayPossible?: boolean | null;
 };
 
 export type CompetitionMatchPage = {
@@ -750,8 +750,8 @@ export type LeagueMatchDto = {
   team2Mvp?: MostValuablePlayerDto;
   matchDayUuid?: string | null;
   leagueUuid?: string | null;
-  delayPossible?: boolean | null;
   indefinitelyRescheduled?: boolean | null;
+  delayPossible?: boolean | null;
 };
 
 export type LeagueMatchPage = {
@@ -880,21 +880,21 @@ export type SeasonDto = {
 export type TeamOfficialDto = {
   uuid?: string;
   name?: string;
-  birthdate?: string;
-  nationality?: string;
-  portraitImageLink?: string;
-  role?: string;
+  birthdate?: string | null;
+  nationality?: string | null;
+  portraitImageLink?: string | null;
+  role?: string | null;
 };
 
 export type TeamPlayerDto = {
   uuid?: string;
   name?: string;
-  birthdate?: string;
-  nationality?: string;
-  portraitImageLink?: string;
-  height?: number;
-  jerseyNumber?: number;
-  position?: string;
+  birthdate?: string | null;
+  nationality?: string | null;
+  portraitImageLink?: string | null;
+  height?: number | null;
+  jerseyNumber?: number | null;
+  position?: string | null;
 };
 
 export type TeamRosterDto = {

--- a/codegen/sams/generated/zod.gen.ts
+++ b/codegen/sams/generated/zod.gen.ts
@@ -141,29 +141,29 @@ export const zVolleyballMatchResultsDto = z.object({
 export const zTeamOfficialDto = z.object({
   uuid: z.string().optional(),
   name: z.string().optional(),
-  birthdate: z.string().optional(),
-  nationality: z.string().optional(),
-  portraitImageLink: z.string().optional(),
-  role: z.string().optional(),
+  birthdate: z.string().nullish(),
+  nationality: z.string().nullish(),
+  portraitImageLink: z.string().nullish(),
+  role: z.string().nullish(),
 });
 
 export const zTeamPlayerDto = z.object({
   uuid: z.string().optional(),
   name: z.string().optional(),
-  birthdate: z.string().optional(),
-  nationality: z.string().optional(),
-  portraitImageLink: z.string().optional(),
+  birthdate: z.string().nullish(),
+  nationality: z.string().nullish(),
+  portraitImageLink: z.string().nullish(),
   height: z
     .int()
     .min(-2147483648, { error: "Invalid value: Expected int32 to be >= -2147483648" })
     .max(2147483647, { error: "Invalid value: Expected int32 to be <= 2147483647" })
-    .optional(),
+    .nullish(),
   jerseyNumber: z
     .int()
     .min(-2147483648, { error: "Invalid value: Expected int32 to be >= -2147483648" })
     .max(2147483647, { error: "Invalid value: Expected int32 to be <= 2147483647" })
-    .optional(),
-  position: z.string().optional(),
+    .nullish(),
+  position: z.string().nullish(),
 });
 
 export const zLinkDto = z.object({
@@ -790,8 +790,8 @@ export const zCompetitionMatchDto = z.object({
   team2Mvp: zMostValuablePlayerDto.optional(),
   matchGroupUuid: z.string().nullish(),
   competitionUuid: z.string().nullish(),
-  delayPossible: z.boolean().nullish(),
   indefinitelyRescheduled: z.boolean().nullish(),
+  delayPossible: z.boolean().nullish(),
 });
 
 export const zCompetitionMatchPage = z.object({
@@ -937,8 +937,8 @@ export const zLeagueMatchDto = z.object({
   team2Mvp: zMostValuablePlayerDto.optional(),
   matchDayUuid: z.string().nullish(),
   leagueUuid: z.string().nullish(),
-  delayPossible: z.boolean().nullish(),
   indefinitelyRescheduled: z.boolean().nullish(),
+  delayPossible: z.boolean().nullish(),
 });
 
 export const zLeagueMatchPage = z.object({

--- a/lambda/sams/sams-teams-sync.ts
+++ b/lambda/sams/sams-teams-sync.ts
@@ -65,35 +65,39 @@ function mapRosterPlayers(
   teamUuid: string,
   players: Array<{
     uuid?: string;
-    name?: string;
-    jerseyNumber?: number;
-    position?: string;
-    portraitImageLink?: string;
+    name?: string | null;
+    jerseyNumber?: number | null;
+    position?: string | null;
+    portraitImageLink?: string | null;
   }> = [],
 ): RosterPlayer[] {
   return players
     .filter((p): p is typeof p & { name: string } => !!p.name?.trim())
     .map((p) => ({
       // The SAMS API sometimes omits uuid; derive a deterministic pseudo uuid from stable fields
-      uuid: p.uuid ?? pseudoRosterUuid(teamUuid, "player", p.name, p.jerseyNumber),
+      uuid: p.uuid ?? pseudoRosterUuid(teamUuid, "player", p.name, p.jerseyNumber ?? undefined),
       name: p.name,
-      jerseyNumber: p.jerseyNumber,
-      position: p.position,
-      portraitImageLink: p.portraitImageLink,
+      ...(p.jerseyNumber != null ? { jerseyNumber: p.jerseyNumber } : {}),
+      ...(p.position ? { position: p.position } : {}),
+      ...(p.portraitImageLink ? { portraitImageLink: p.portraitImageLink } : {}),
     }));
 }
 
 function mapRosterOfficials(
   teamUuid: string,
-  officials: Array<{ uuid?: string; name?: string; role?: string }> = [],
+  officials: Array<{
+    uuid?: string;
+    name?: string | null;
+    role?: string | null;
+  }> = [],
 ): RosterOfficial[] {
   return officials
     .filter((o): o is typeof o & { name: string } => !!o.name?.trim())
     .map((o) => ({
       // The SAMS API sometimes omits uuid; derive a deterministic pseudo uuid from stable fields
-      uuid: o.uuid ?? pseudoRosterUuid(teamUuid, "official", o.name, o.role),
+      uuid: o.uuid ?? pseudoRosterUuid(teamUuid, "official", o.name, o.role ?? undefined),
       name: o.name,
-      role: o.role,
+      ...(o.role ? { role: o.role } : {}),
     }));
 }
 
@@ -305,7 +309,12 @@ const lambdaHandler: APIGatewayProxyHandler = async () => {
       teamsProcessed++;
 
       try {
-        const { data: rosterData } = await getTeamRosterByTeamUuid({ path: { uuid: team.uuid } });
+        const { data: rosterData, error: rosterError } = await getTeamRosterByTeamUuid({
+          path: { uuid: team.uuid },
+        });
+        if (rosterError) {
+          throw rosterError;
+        }
         if (rosterData) {
           const rosterItem: SyncedRosterItem = {
             teamUuid: team.uuid,

--- a/lambda/sams/sams-teams-sync.ts
+++ b/lambda/sams/sams-teams-sync.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { injectLambdaContext } from "@aws-lambda-powertools/logger/middleware";
 import { captureLambdaHandler } from "@aws-lambda-powertools/tracer/middleware";
 import {
@@ -50,7 +51,18 @@ type SyncedRosterItem = {
   ttl: number;
 };
 
+function pseudoRosterUuid(
+  teamUuid: string,
+  kind: "player" | "official",
+  ...parts: (string | number | undefined)[]
+): string {
+  const input = [teamUuid, kind, ...parts.map((part) => String(part ?? ""))].join("|");
+  const hex = createHash("sha256").update(input).digest("hex").slice(0, 32);
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
+}
+
 function mapRosterPlayers(
+  teamUuid: string,
   players: Array<{
     uuid?: string;
     name?: string;
@@ -62,8 +74,8 @@ function mapRosterPlayers(
   return players
     .filter((p): p is typeof p & { name: string } => !!p.name?.trim())
     .map((p) => ({
-      // The SAMS API sometimes omits uuid; assign a pseudo uuid so every player has a stable identity
-      uuid: p.uuid ?? crypto.randomUUID(),
+      // The SAMS API sometimes omits uuid; derive a deterministic pseudo uuid from stable fields
+      uuid: p.uuid ?? pseudoRosterUuid(teamUuid, "player", p.name, p.jerseyNumber),
       name: p.name,
       jerseyNumber: p.jerseyNumber,
       position: p.position,
@@ -72,13 +84,14 @@ function mapRosterPlayers(
 }
 
 function mapRosterOfficials(
+  teamUuid: string,
   officials: Array<{ uuid?: string; name?: string; role?: string }> = [],
 ): RosterOfficial[] {
   return officials
     .filter((o): o is typeof o & { name: string } => !!o.name?.trim())
     .map((o) => ({
-      // The SAMS API sometimes omits uuid; assign a pseudo uuid so every official has a stable identity
-      uuid: o.uuid ?? crypto.randomUUID(),
+      // The SAMS API sometimes omits uuid; derive a deterministic pseudo uuid from stable fields
+      uuid: o.uuid ?? pseudoRosterUuid(teamUuid, "official", o.name, o.role),
       name: o.name,
       role: o.role,
     }));
@@ -297,8 +310,8 @@ const lambdaHandler: APIGatewayProxyHandler = async () => {
           const rosterItem: SyncedRosterItem = {
             teamUuid: team.uuid,
             type: "roster",
-            players: mapRosterPlayers(rosterData.players),
-            officials: mapRosterOfficials(rosterData.officials),
+            players: mapRosterPlayers(team.uuid, rosterData.players),
+            officials: mapRosterOfficials(team.uuid, rosterData.officials),
             updatedAt: new Date().toISOString(),
             ttl: Math.floor(Date.now() / 1000) + 60 * 60 * 24 * 365,
           };
@@ -310,6 +323,12 @@ const lambdaHandler: APIGatewayProxyHandler = async () => {
         Sentry.captureException(error, {
           extra: { teamUuid: team.uuid, teamName: team.name },
         });
+        await samsEntities.roster
+          .delete({ teamUuid: team.uuid })
+          .go()
+          .catch((deleteError) => {
+            console.warn(`Failed to delete stale roster for team ${team.uuid}:`, deleteError);
+          });
         rostersFailed++;
       }
 

--- a/lambda/sams/sams-teams-sync.ts
+++ b/lambda/sams/sams-teams-sync.ts
@@ -59,23 +59,29 @@ function mapRosterPlayers(
     portraitImageLink?: string;
   }> = [],
 ): RosterPlayer[] {
-  return players.map((p) => ({
-    uuid: p.uuid,
-    name: p.name,
-    jerseyNumber: p.jerseyNumber,
-    position: p.position,
-    portraitImageLink: p.portraitImageLink,
-  }));
+  return players
+    .filter((p): p is typeof p & { name: string } => !!p.name?.trim())
+    .map((p) => ({
+      // The SAMS API sometimes omits uuid; assign a pseudo uuid so every player has a stable identity
+      uuid: p.uuid ?? crypto.randomUUID(),
+      name: p.name,
+      jerseyNumber: p.jerseyNumber,
+      position: p.position,
+      portraitImageLink: p.portraitImageLink,
+    }));
 }
 
 function mapRosterOfficials(
   officials: Array<{ uuid?: string; name?: string; role?: string }> = [],
 ): RosterOfficial[] {
-  return officials.map((o) => ({
-    uuid: o.uuid,
-    name: o.name,
-    role: o.role,
-  }));
+  return officials
+    .filter((o): o is typeof o & { name: string } => !!o.name?.trim())
+    .map((o) => ({
+      // The SAMS API sometimes omits uuid; assign a pseudo uuid so every official has a stable identity
+      uuid: o.uuid ?? crypto.randomUUID(),
+      name: o.name,
+      role: o.role,
+    }));
 }
 
 async function resolveConfiguredSamsClubsFromStorage() {

--- a/lambda/sams/sams-teams-sync.ts
+++ b/lambda/sams/sams-teams-sync.ts
@@ -4,6 +4,7 @@ import {
   getAllLeagueHierarchies,
   getAllLeagues,
   getAllSeasons,
+  getTeamRosterByTeamUuid,
   getTeamsForLeague,
 } from "@codegen/sams/generated";
 import middy from "@middy/core";
@@ -14,6 +15,7 @@ import { resolveConfiguredSamsSportsclubUuids, SAMS_TARGET_CLUB_SLUGS } from "..
 import { parseLambdaEnv } from "../utils/env";
 import { createDynamoDocClient, createLambdaResources } from "../utils/resources";
 import { Sentry } from "../utils/sentry";
+import type { RosterOfficial, RosterPlayer } from "./types";
 import { SamsTeamsSyncLambdaEnvironmentSchema } from "./types";
 
 const { logger, tracer } = createLambdaResources("sams-teams-sync");
@@ -38,6 +40,43 @@ type SyncedTeamItem = {
   updatedAt: string;
   ttl: number;
 };
+
+type SyncedRosterItem = {
+  teamUuid: string;
+  type: "roster";
+  players: RosterPlayer[];
+  officials: RosterOfficial[];
+  updatedAt: string;
+  ttl: number;
+};
+
+function mapRosterPlayers(
+  players: Array<{
+    uuid?: string;
+    name?: string;
+    jerseyNumber?: number;
+    position?: string;
+    portraitImageLink?: string;
+  }> = [],
+): RosterPlayer[] {
+  return players.map((p) => ({
+    uuid: p.uuid,
+    name: p.name,
+    jerseyNumber: p.jerseyNumber,
+    position: p.position,
+    portraitImageLink: p.portraitImageLink,
+  }));
+}
+
+function mapRosterOfficials(
+  officials: Array<{ uuid?: string; name?: string; role?: string }> = [],
+): RosterOfficial[] {
+  return officials.map((o) => ({
+    uuid: o.uuid,
+    name: o.name,
+    role: o.role,
+  }));
+}
 
 async function resolveConfiguredSamsClubsFromStorage() {
   const clubResponse = await samsEntities.club.query.byType({ type: "club" }).go({ pages: "all" });
@@ -237,15 +276,41 @@ const lambdaHandler: APIGatewayProxyHandler = async () => {
     });
     Sentry.setMeasurement("sams_teams_sync.teams_found", allTeams.length, "none");
 
-    // Step 5: Store teams in DynamoDB
+    // Step 5: Store teams (and their rosters) in DynamoDB
     let teamsProcessed = 0;
+    let rostersProcessed = 0;
+    let rostersFailed = 0;
 
     for (const team of allTeams) {
       await samsEntities.team.upsert(team).go();
       teamsProcessed++;
+
+      try {
+        const { data: rosterData } = await getTeamRosterByTeamUuid({ path: { uuid: team.uuid } });
+        if (rosterData) {
+          const rosterItem: SyncedRosterItem = {
+            teamUuid: team.uuid,
+            type: "roster",
+            players: mapRosterPlayers(rosterData.players),
+            officials: mapRosterOfficials(rosterData.officials),
+            updatedAt: new Date().toISOString(),
+            ttl: Math.floor(Date.now() / 1000) + 60 * 60 * 24 * 365,
+          };
+          await samsEntities.roster.upsert(rosterItem).go();
+          rostersProcessed++;
+        }
+      } catch (error) {
+        console.warn(`Failed to fetch roster for team ${team.name} (${team.uuid}):`, error);
+        Sentry.captureException(error, {
+          extra: { teamUuid: team.uuid, teamName: team.name },
+        });
+        rostersFailed++;
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 500)); // Rate limiting
     }
 
-    // Step 6: Delete stale teams (not updated in this sync)
+    // Step 6: Delete stale teams (not updated in this sync) and their rosters
     const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString();
     const existingResponse = await samsEntities.team.query
       .byType({ type: "team" })
@@ -254,6 +319,7 @@ const lambdaHandler: APIGatewayProxyHandler = async () => {
     for (const existingTeam of existingResponse.data) {
       if (existingTeam.updatedAt < oneHourAgo) {
         await samsEntities.team.delete({ uuid: existingTeam.uuid }).go();
+        await samsEntities.roster.delete({ teamUuid: existingTeam.uuid }).go();
         console.log(`Deleted stale team: ${existingTeam.name}`);
         teamsDeleted++;
       }
@@ -263,12 +329,16 @@ const lambdaHandler: APIGatewayProxyHandler = async () => {
       success: true,
       teamsProcessed,
       teamsDeleted,
+      rostersProcessed,
+      rostersFailed,
       timestamp: new Date().toISOString(),
     };
 
     console.log("Teams sync completed:", result);
     Sentry.setMeasurement("sams_teams_sync.teams_processed", teamsProcessed, "none");
     Sentry.setMeasurement("sams_teams_sync.teams_deleted", teamsDeleted, "none");
+    Sentry.setMeasurement("sams_teams_sync.rosters_processed", rostersProcessed, "none");
+    Sentry.setMeasurement("sams_teams_sync.rosters_failed", rostersFailed, "none");
     Sentry.addBreadcrumb({
       category: "sync",
       message: "Teams sync completed",

--- a/lambda/sams/types.ts
+++ b/lambda/sams/types.ts
@@ -190,6 +190,67 @@ export const TeamsResponseSchema = z.object({
 export type TeamsResponse = z.infer<typeof TeamsResponseSchema>;
 
 // ============================================================================
+// Roster Schemas & Types
+// ============================================================================
+
+/**
+ * A player entry within a synced SAMS team roster
+ */
+const RosterPlayerSchema = z.object({
+  uuid: z.string().optional(),
+  name: z.string().optional(),
+  jerseyNumber: z.number().optional(),
+  position: z.string().optional(),
+  portraitImageLink: z.string().optional(),
+});
+
+export type RosterPlayer = z.infer<typeof RosterPlayerSchema>;
+
+/**
+ * An official/coach entry within a synced SAMS team roster
+ */
+const RosterOfficialSchema = z.object({
+  uuid: z.string().optional(),
+  name: z.string().optional(),
+  role: z.string().optional(),
+});
+
+export type RosterOfficial = z.infer<typeof RosterOfficialSchema>;
+
+/**
+ * Base roster schema for DynamoDB
+ */
+const BaseRosterItemSchema = z.object({
+  type: z.literal("roster").default("roster").describe("GSI partition key type"),
+  teamUuid: z.string(),
+  players: z.array(RosterPlayerSchema).default([]),
+  officials: z.array(RosterOfficialSchema).default([]),
+  updatedAt: z.string(),
+  ttl: z.number(), // DynamoDB TTL field
+});
+
+/**
+ * Internal DynamoDB representation of a roster
+ * Automatically strips undefined values to save storage
+ */
+export const RosterItemSchema = BaseRosterItemSchema.transform((data) => {
+  // Remove undefined values to save DynamoDB storage
+  return Object.fromEntries(Object.entries(data).filter(([_, v]) => v !== undefined));
+});
+
+export type RosterItem = z.infer<typeof RosterItemSchema>;
+
+/**
+ * Public API response for a team roster
+ * Excludes internal fields (ttl)
+ */
+export const RosterResponseSchema = BaseRosterItemSchema.omit({
+  ttl: true,
+});
+
+export type RosterResponse = z.infer<typeof RosterResponseSchema>;
+
+// ============================================================================
 // Seasons Schemas & Types
 // ============================================================================
 

--- a/lambda/sams/types.ts
+++ b/lambda/sams/types.ts
@@ -195,7 +195,7 @@ export type TeamsResponse = z.infer<typeof TeamsResponseSchema>;
 
 /**
  * A player entry within a synced SAMS team roster
- * uuid and name are always present: sams-teams-sync.ts assigns a pseudo uuid when the
+ * uuid and name are always present: sams-teams-sync.ts derives a deterministic pseudo uuid when the
  * external API omits one, and filters out players without a name.
  */
 const RosterPlayerSchema = z.object({
@@ -210,7 +210,7 @@ export type RosterPlayer = z.infer<typeof RosterPlayerSchema>;
 
 /**
  * An official/coach entry within a synced SAMS team roster
- * uuid and name are always present: sams-teams-sync.ts assigns a pseudo uuid when the
+ * uuid and name are always present: sams-teams-sync.ts derives a deterministic pseudo uuid when the
  * external API omits one, and filters out officials without a name.
  */
 const RosterOfficialSchema = z.object({

--- a/lambda/sams/types.ts
+++ b/lambda/sams/types.ts
@@ -195,10 +195,12 @@ export type TeamsResponse = z.infer<typeof TeamsResponseSchema>;
 
 /**
  * A player entry within a synced SAMS team roster
+ * uuid and name are always present: sams-teams-sync.ts assigns a pseudo uuid when the
+ * external API omits one, and filters out players without a name.
  */
 const RosterPlayerSchema = z.object({
-  uuid: z.string().optional(),
-  name: z.string().optional(),
+  uuid: z.string(),
+  name: z.string(),
   jerseyNumber: z.number().optional(),
   position: z.string().optional(),
   portraitImageLink: z.string().optional(),
@@ -208,10 +210,12 @@ export type RosterPlayer = z.infer<typeof RosterPlayerSchema>;
 
 /**
  * An official/coach entry within a synced SAMS team roster
+ * uuid and name are always present: sams-teams-sync.ts assigns a pseudo uuid when the
+ * external API omits one, and filters out officials without a name.
  */
 const RosterOfficialSchema = z.object({
-  uuid: z.string().optional(),
-  name: z.string().optional(),
+  uuid: z.string(),
+  name: z.string(),
   role: z.string().optional(),
 });
 

--- a/lib/db/electrodb-client.ts
+++ b/lib/db/electrodb-client.ts
@@ -28,7 +28,7 @@ import {
   VolunteerTokenEntity,
 } from "./electrodb-entities";
 import { getContentTableName, getSamsTableName } from "./env";
-import { SamsClubEntity, SamsTeamEntity } from "./sams-electrodb-entities";
+import { SamsClubEntity, SamsRosterEntity, SamsTeamEntity } from "./sams-electrodb-entities";
 
 /** All entities registered in the service */
 const entityMap = {
@@ -75,6 +75,7 @@ export function db(): ReturnType<typeof createDb> {
 const samsEntityMap = {
   club: SamsClubEntity,
   team: SamsTeamEntity,
+  roster: SamsRosterEntity,
 } as const;
 
 /**

--- a/lib/db/electrodb-entities.test.ts
+++ b/lib/db/electrodb-entities.test.ts
@@ -21,7 +21,7 @@ import {
   VolunteerSignupEntity,
   VolunteerTokenEntity,
 } from "./electrodb-entities";
-import { SamsClubEntity, SamsTeamEntity } from "./sams-electrodb-entities";
+import { SamsClubEntity, SamsRosterEntity, SamsTeamEntity } from "./sams-electrodb-entities";
 import {
   busSchema,
   eventSchema,
@@ -30,6 +30,7 @@ import {
   memberSchema,
   newsSchema,
   samsClubSchema,
+  samsRosterSchema,
   samsTeamSchema,
   sponsorSchema,
   teamSchema,
@@ -170,6 +171,10 @@ describe("SAMS ElectroDB ↔ Zod drift detection", () => {
 
   it("SamsTeam entity attributes match samsTeamSchema", () => {
     checkDrift("SamsTeam", samsTeamSchema, SamsTeamEntity);
+  });
+
+  it("SamsRoster entity attributes match samsRosterSchema", () => {
+    checkDrift("SamsRoster", samsRosterSchema, SamsRosterEntity);
   });
 });
 

--- a/lib/db/sams-electrodb-entities.ts
+++ b/lib/db/sams-electrodb-entities.ts
@@ -1,7 +1,7 @@
 /**
  * ElectroDB entity definitions for the single SAMS data table.
  *
- * Single table design: SamsClub and SamsTeam share one DynamoDB table (`SAMS_TABLE_NAME`).
+ * Single table design: SamsClub, SamsTeam, and SamsRoster share one DynamoDB table (`SAMS_TABLE_NAME`).
  *
  * Table key structure:
  *   PK  (pk)     — entity_type#uuid  (e.g. "samsclub#uuid")
@@ -92,10 +92,37 @@ export const SamsTeamEntity = new Entity({
   },
 } as const);
 
+// ---------------------------------------------------------------------------
+// SamsRoster entity
+// ---------------------------------------------------------------------------
+
+export const SamsRosterEntity = new Entity({
+  model: {
+    entity: "samsroster",
+    service: "vcm",
+    version: "1",
+  },
+  attributes: {
+    teamUuid: { type: "string", required: true },
+    type: { type: "string", required: true, default: () => "roster" as const },
+    players: { type: "any", required: true },
+    officials: { type: "any", required: true },
+    updatedAt: { type: "string", required: true },
+    ttl: { type: "number", required: true },
+  },
+  indexes: {
+    byTeamUuid: {
+      pk: { field: "pk", composite: ["teamUuid"] },
+      sk: { field: "sk", composite: [] },
+    },
+  },
+} as const);
+
 /** All SAMS entities — useful for building a service */
 export const SamsEntities = {
   club: SamsClubEntity,
   team: SamsTeamEntity,
+  roster: SamsRosterEntity,
 } as const;
 
 export type SamsEntityName = keyof typeof SamsEntities;

--- a/lib/db/sams-electrodb-entities.ts
+++ b/lib/db/sams-electrodb-entities.ts
@@ -115,6 +115,11 @@ export const SamsRosterEntity = new Entity({
       pk: { field: "pk", composite: ["teamUuid"] },
       sk: { field: "sk", composite: [] },
     },
+    byType: {
+      index: SamsTableIndexes.gsi1,
+      pk: { field: "gsi1pk", composite: ["type"] },
+      sk: { field: "gsi1sk", composite: ["teamUuid"] },
+    },
   },
 } as const);
 

--- a/lib/db/schemas.ts
+++ b/lib/db/schemas.ts
@@ -208,6 +208,34 @@ export const samsTeamSchema = z.object({
 export type SamsClubInput = z.infer<typeof samsClubSchema>;
 export type SamsTeamInput = z.infer<typeof samsTeamSchema>;
 
+/** A player entry within a SAMS team roster */
+export const samsRosterPlayerSchema = z.object({
+  uuid: z.string().optional(),
+  name: z.string().optional(),
+  jerseyNumber: z.number().optional(),
+  position: z.string().optional(),
+  portraitImageLink: z.string().optional(),
+});
+
+/** An official/coach entry within a SAMS team roster */
+export const samsRosterOfficialSchema = z.object({
+  uuid: z.string().optional(),
+  name: z.string().optional(),
+  role: z.string().optional(),
+});
+
+/** SAMS team roster record — players + officials for the current season (synced from external SAMS API) */
+export const samsRosterSchema = z.object({
+  teamUuid: z.string().min(1),
+  type: z.literal("roster").default("roster").describe("Entity type discriminator for GSI queries"),
+  players: z.array(samsRosterPlayerSchema).default([]),
+  officials: z.array(samsRosterOfficialSchema).default([]),
+  updatedAt: z.iso.datetime(),
+  ttl: z.number().int().positive().describe("Unix timestamp for DynamoDB TTL (1-year expiry)"),
+});
+
+export type SamsRosterInput = z.infer<typeof samsRosterSchema>;
+
 // ---------------------------------------------------------------------------
 // Volunteer Event Planner schemas
 // ---------------------------------------------------------------------------

--- a/lib/db/schemas.ts
+++ b/lib/db/schemas.ts
@@ -208,19 +208,27 @@ export const samsTeamSchema = z.object({
 export type SamsClubInput = z.infer<typeof samsClubSchema>;
 export type SamsTeamInput = z.infer<typeof samsTeamSchema>;
 
-/** A player entry within a SAMS team roster */
+/**
+ * A player entry within a SAMS team roster
+ * uuid and name are always present: sams-teams-sync.ts assigns a pseudo uuid when the
+ * external API omits one, and filters out players without a name.
+ */
 export const samsRosterPlayerSchema = z.object({
-  uuid: z.string().optional(),
-  name: z.string().optional(),
+  uuid: z.string(),
+  name: z.string(),
   jerseyNumber: z.number().optional(),
   position: z.string().optional(),
   portraitImageLink: z.string().optional(),
 });
 
-/** An official/coach entry within a SAMS team roster */
+/**
+ * An official/coach entry within a SAMS team roster
+ * uuid and name are always present: sams-teams-sync.ts assigns a pseudo uuid when the
+ * external API omits one, and filters out officials without a name.
+ */
 export const samsRosterOfficialSchema = z.object({
-  uuid: z.string().optional(),
-  name: z.string().optional(),
+  uuid: z.string(),
+  name: z.string(),
   role: z.string().optional(),
 });
 

--- a/lib/db/schemas.ts
+++ b/lib/db/schemas.ts
@@ -210,7 +210,7 @@ export type SamsTeamInput = z.infer<typeof samsTeamSchema>;
 
 /**
  * A player entry within a SAMS team roster
- * uuid and name are always present: sams-teams-sync.ts assigns a pseudo uuid when the
+ * uuid and name are always present: sams-teams-sync.ts derives a deterministic pseudo uuid when the
  * external API omits one, and filters out players without a name.
  */
 export const samsRosterPlayerSchema = z.object({
@@ -223,7 +223,7 @@ export const samsRosterPlayerSchema = z.object({
 
 /**
  * An official/coach entry within a SAMS team roster
- * uuid and name are always present: sams-teams-sync.ts assigns a pseudo uuid when the
+ * uuid and name are always present: sams-teams-sync.ts derives a deterministic pseudo uuid when the
  * external API omits one, and filters out officials without a name.
  */
 export const samsRosterOfficialSchema = z.object({


### PR DESCRIPTION
This update introduces the ability to fetch and display team rosters from the SAMS API, including players and officials. It implements the `getSamsRosterByTeamUuid` function, a new React Query hook `useSamsRoster`, and a `TeamRoster` component to present the data. The server functions and queries have been updated to handle the new roster data, and tests have been added to ensure data integrity. Additionally, unique keys are ensured for player and official lists in the `TeamRoster` component.

Fixes #352