### PR TITLE
Add support for apex and www aliases in production custom domains

### DIFF
--- a/lib/webapp-stack.test.ts
+++ b/lib/webapp-stack.test.ts
@@ -306,7 +306,7 @@ describe("WebAppStack", () => {
 
     template.hasResourceProperties("AWS::CloudFront::Distribution", {
       DistributionConfig: {
-        Aliases: ["vcmuellheim.de", "www.vcmuellheim.de"],
+        Aliases: Match.arrayWith(["vcmuellheim.de", "www.vcmuellheim.de"]),
       },
     });
 

--- a/lib/webapp-stack.test.ts
+++ b/lib/webapp-stack.test.ts
@@ -1,6 +1,8 @@
 import { existsSync, mkdirSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { Match, Template } from "aws-cdk-lib/assertions";
+import * as acm from "aws-cdk-lib/aws-certificatemanager";
+import * as route53 from "aws-cdk-lib/aws-route53";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { CACHE_TABLE_ENV_VAR, CONTENT_TABLE_ENV_VAR } from "./db/env";
 import { createTestApp } from "./test-helpers";
@@ -276,5 +278,48 @@ describe("WebAppStack", () => {
     }).not.toThrow();
 
     expect(buildMock).not.toHaveBeenCalled();
+  });
+
+  it("configures apex and www aliases for prod custom domains", () => {
+    const app = createTestApp();
+    const dependencies = createDependencies();
+
+    const stack = new WebAppStack(app, "TestStack", {
+      env: testEnv,
+      stackProps: {
+        environment: "prod",
+        branch: "",
+      },
+      hostedZone: route53.HostedZone.fromHostedZoneAttributes(app, "HostedZone", {
+        hostedZoneId: "Z1111111111111",
+        zoneName: "vcmuellheim.de",
+      }),
+      cloudFrontCertificate: acm.Certificate.fromCertificateArn(
+        app,
+        "CloudFrontCertificate",
+        "arn:aws:acm:us-east-1:123456789012:certificate/test-cert",
+      ),
+      ...dependencies,
+    });
+
+    const template = Template.fromStack(stack);
+
+    template.hasResourceProperties("AWS::CloudFront::Distribution", {
+      DistributionConfig: {
+        Aliases: ["vcmuellheim.de", "www.vcmuellheim.de"],
+      },
+    });
+
+    template.resourceCountIs("AWS::Route53::RecordSet", 2);
+
+    template.hasResourceProperties("AWS::Route53::RecordSet", {
+      Name: "vcmuellheim.de.",
+      Type: "A",
+    });
+
+    template.hasResourceProperties("AWS::Route53::RecordSet", {
+      Name: "www.vcmuellheim.de.",
+      Type: "A",
+    });
   });
 });

--- a/lib/webapp-stack.ts
+++ b/lib/webapp-stack.ts
@@ -67,6 +67,8 @@ export class WebAppStack extends cdk.Stack {
     const isCdkDestroy = process.env.CDK_DESTROY === "true";
     // prod: vcmuellheim.de  dev: dev.new.vcmuellheim.de  feature: dev-<branch>.new.vcmuellheim.de
     const webappDomain = buildWebappDomain(environment, branch);
+    const webappDomainAliases =
+      isProd && webappDomain ? [webappDomain, `www.${webappDomain}`] : [webappDomain];
     const webappUrl = buildWebappUrl(environment, branch);
 
     if (!isCdkDestroy && !process.env.BETTER_AUTH_SECRET) {
@@ -287,7 +289,7 @@ export class WebAppStack extends cdk.Stack {
       comment: isProd ? "VCM WebApp (Prod)" : `VCM WebApp (${environment}${branchSuffix})`,
       ...(props.cloudFrontCertificate && props.hostedZone
         ? {
-            domainNames: [webappDomain],
+            domainNames: webappDomainAliases,
             certificate: props.cloudFrontCertificate,
           }
         : {}),
@@ -315,6 +317,16 @@ export class WebAppStack extends cdk.Stack {
           new route53Targets.CloudFrontTarget(this.distribution),
         ),
       });
+
+      if (isProd) {
+        new route53.ARecord(this, "WebAppWwwARecord", {
+          zone: props.hostedZone,
+          recordName: `www.${webappDomain}`,
+          target: route53.RecordTarget.fromAlias(
+            new route53Targets.CloudFrontTarget(this.distribution),
+          ),
+        });
+      }
 
       this.webappUrl = webappUrl;
     } else {

--- a/lib/webapp-stack.ts
+++ b/lib/webapp-stack.ts
@@ -67,8 +67,9 @@ export class WebAppStack extends cdk.Stack {
     const isCdkDestroy = process.env.CDK_DESTROY === "true";
     // prod: vcmuellheim.de  dev: dev.new.vcmuellheim.de  feature: dev-<branch>.new.vcmuellheim.de
     const webappDomain = buildWebappDomain(environment, branch);
-    const webappDomainAliases =
-      isProd && webappDomain ? [webappDomain, `www.${webappDomain}`] : [webappDomain];
+    const webappDomainAliases = isProd
+      ? [webappDomain, `www.${webappDomain}`]
+      : [webappDomain];
     const webappUrl = buildWebappUrl(environment, branch);
 
     if (!isCdkDestroy && !process.env.BETTER_AUTH_SECRET) {


### PR DESCRIPTION
Implement support for apex and www domain aliases in the production environment, enhancing domain configuration for CloudFront and Route 53.