### PR TITLE
Fix mail forwarding failures from duplicate DKIM-Signature headers

### DIFF
--- a/lambda/mail/mail-forward.test.ts
+++ b/lambda/mail/mail-forward.test.ts
@@ -204,6 +204,43 @@ describe("mail-forward Lambda", () => {
       );
     });
 
+    test("removes DKIM-Signature headers before forwarding", async () => {
+      mockByProxyEmailGo.mockResolvedValue({
+        data: [
+          {
+            id: "m1",
+            proxyEmail: "max.mustermann@vcmuellheim.de",
+            privateEmail: "max@example.com",
+          },
+        ],
+      });
+      s3Mock.on(GetObjectCommand).resolves({
+        Body: {
+          transformToString: vi
+            .fn()
+            .mockResolvedValue(
+              [
+                "DKIM-Signature: v=1; a=rsa-sha256; d=example.com; s=selector1; h=from:to:subject; b=abc123",
+                "DKIM-Signature: v=1; a=rsa-sha256; d=gmx.net; s=selector2; h=from:to:subject; b=def456",
+                "From: sender@example.com",
+                "To: max.mustermann@vcmuellheim.de",
+                "Subject: Test",
+                "",
+                "Hello world",
+              ].join("\n"),
+            ),
+        } as never,
+      });
+
+      await handler(makeEvent("emails/dkim-test.eml"), mockLambdaContext as never);
+
+      const rawMime = Buffer.from(
+        getForwardCalls()[0].args[0].input.Content!.Raw!.Data!,
+      ).toString();
+      expect(rawMime).not.toMatch(/^DKIM-Signature:/im);
+      expect(getForwardCalls()).toHaveLength(1);
+    });
+
     test("removes original Return-Path before forwarding", async () => {
       mockByProxyEmailGo.mockResolvedValue({
         data: [

--- a/lambda/mail/mail-forward.ts
+++ b/lambda/mail/mail-forward.ts
@@ -315,6 +315,9 @@ function splitMimeIntoHeadersAndBody(rawMime: string): { headers: string; body: 
   };
 }
 
+const BLOCKED_FORWARD_HEADER_PATTERN =
+  /^(return-path|sender|dkim-signature|arc-seal|arc-message-signature|arc-authentication-results|authentication-results|received-spf):/i;
+
 function stripBlockedForwardHeaders(headers: string): string {
   const headerLines = headers.split(/\r?\n/);
   const strippedHeaders: string[] = [];
@@ -328,7 +331,7 @@ function stripBlockedForwardHeaders(headers: string): string {
       continue;
     }
 
-    skipContinuation = /^(return-path|sender):/i.test(line);
+    skipContinuation = BLOCKED_FORWARD_HEADER_PATTERN.test(line);
     if (!skipContinuation) {
       strippedHeaders.push(line);
     }


### PR DESCRIPTION
## Summary
- Strip inbound authentication/signing headers (`DKIM-Signature`, ARC, `Authentication-Results`, `Received-SPF`) before SES raw send in the mail-forward Lambda
- Prevents SES `BadRequestException: Duplicate header 'DKIM-Signature'` when forwarding mail from providers with multiple signing hops
- Adds test coverage for DKIM header removal

Fixes VOLLEYBALL-WEBSITE-68, VOLLEYBALL-WEBSITE-69, and VOLLEYBALL-WEBSITE-6A.

## Test plan
- [x] `vp test lambda/mail/mail-forward.test.ts` (20 tests pass)
- [ ] Deploy mail-forward Lambda to prod and verify inbound forwarding succeeds for messages with multiple DKIM signatures