### PR TITLE
Fix prod email alias suffix and handle empty SAMS responses.

### DIFF
--- a/app/src/routes/admin/_layout/members.tsx
+++ b/app/src/routes/admin/_layout/members.tsx
@@ -46,15 +46,20 @@ import z from "zod";
 
 const bytesToMB = (bytes: number, decimals = 1) => (bytes / (1024 * 1024)).toFixed(decimals);
 const isValidEmail = (value: string) => z.email().safeParse(value).success;
+const clientHostname = typeof window !== "undefined" ? window.location.hostname : undefined;
 const cdkEnvironment = import.meta.env.CDK_ENVIRONMENT;
-const defaultProxyAliasDomain = getProxyAliasDomain(cdkEnvironment);
+const defaultProxyAliasDomain = getProxyAliasDomain(cdkEnvironment, clientHostname);
 
 const getProxyAliasInputParts = (proxyEmail?: string) => {
   if (!proxyEmail) {
     return {
       domain: defaultProxyAliasDomain,
       baseLocalPart: "",
-      branchName: getProxyAliasBranchName(cdkEnvironment, import.meta.env.VITE_BRANCH_NAME),
+      branchName: getProxyAliasBranchName(
+        cdkEnvironment,
+        import.meta.env.VITE_BRANCH_NAME,
+        defaultProxyAliasDomain,
+      ),
     };
   }
 
@@ -66,6 +71,7 @@ const getProxyAliasInputParts = (proxyEmail?: string) => {
     branchName: getProxyAliasBranchName(
       cdkEnvironment,
       import.meta.env.VITE_BRANCH_NAME || parsed.branchName,
+      parsed.domain,
     ),
   };
 };

--- a/app/src/server/functions/member-alias.test.ts
+++ b/app/src/server/functions/member-alias.test.ts
@@ -3,6 +3,7 @@ import {
   canonicalizeProxyAlias,
   getProxyAliasBranchName,
   getProxyAliasDomain,
+  isProdProxyAliasDomain,
   normalizeAliasLocalPart,
   parseProxyAlias,
   suggestProxyAlias,
@@ -88,6 +89,23 @@ describe("proxy alias environment helpers", () => {
   test("uses the development recipient domain and branch suffix outside prod", () => {
     expect(getProxyAliasDomain("dev")).toBe("new.vcmuellheim.de");
     expect(getProxyAliasBranchName("dev", "email-proxy")).toBe("email-proxy");
+  });
+
+  test("infers production domain from hostname when build-time env is missing", () => {
+    expect(getProxyAliasDomain(undefined, "vcmuellheim.de")).toBe("vcmuellheim.de");
+    expect(getProxyAliasDomain(undefined, "www.vcmuellheim.de")).toBe("vcmuellheim.de");
+    expect(getProxyAliasDomain(undefined, "dev.new.vcmuellheim.de")).toBe("new.vcmuellheim.de");
+  });
+
+  test("hides branch suffix on production recipient domains", () => {
+    expect(isProdProxyAliasDomain("vcmuellheim.de")).toBe(true);
+    expect(getProxyAliasBranchName("dev", "main", "vcmuellheim.de")).toBeUndefined();
+    expect(getProxyAliasBranchName(undefined, "main", "vcmuellheim.de")).toBeUndefined();
+  });
+
+  test("hides the main branch suffix outside prod", () => {
+    expect(getProxyAliasBranchName("dev", "main", "new.vcmuellheim.de")).toBeUndefined();
+    expect(getProxyAliasBranchName(undefined, "main", "new.vcmuellheim.de")).toBeUndefined();
   });
 });
 

--- a/app/src/server/functions/member-alias.ts
+++ b/app/src/server/functions/member-alias.ts
@@ -83,17 +83,41 @@ export function suggestProxyAlias(
   return formatProxyAlias(localPartWithCounter, domain, branchName);
 }
 
-export function getProxyAliasDomain(cdkEnvironment = process.env.CDK_ENVIRONMENT): string {
-  return cdkEnvironment === "prod" ? Mail.prod.recipientDomain : Mail.dev.recipientDomain;
+export function isProdProxyAliasDomain(domain: string): boolean {
+  return domain === Mail.prod.recipientDomain;
+}
+
+export function getProxyAliasDomain(
+  cdkEnvironment = process.env.CDK_ENVIRONMENT,
+  hostname?: string,
+): string {
+  if (cdkEnvironment === "prod" || isProdProxyAliasHostname(hostname)) {
+    return Mail.prod.recipientDomain;
+  }
+
+  return Mail.dev.recipientDomain;
+}
+
+function isProdProxyAliasHostname(hostname?: string): boolean {
+  if (!hostname) {
+    return false;
+  }
+
+  return hostname === Mail.prod.recipientDomain || hostname === `www.${Mail.prod.recipientDomain}`;
 }
 
 export function getProxyAliasBranchName(
   cdkEnvironment = process.env.CDK_ENVIRONMENT,
   branchName = process.env.BRANCH_NAME,
+  domain?: string,
 ): string | undefined {
-  if (cdkEnvironment === "prod") {
+  if (cdkEnvironment === "prod" || (domain && isProdProxyAliasDomain(domain))) {
     return undefined;
   }
 
-  return branchName || undefined;
+  if (!branchName || branchName === "main") {
+    return undefined;
+  }
+
+  return branchName;
 }

--- a/lambda/sams/sams-league-matches.ts
+++ b/lambda/sams/sams-league-matches.ts
@@ -78,7 +78,24 @@ async function fetchAllLeagueMatchesForSportsclubs({
       });
 
       if (!data) {
-        if (currentPage === 0) throw new Error(`SAMS API returned no data on page ${currentPage}`);
+        if (currentPage === 0) {
+          console.warn("SAMS API returned no data on first page", {
+            page: currentPage,
+            sportsclubUuid,
+            league,
+            season,
+            team,
+          });
+          Sentry.metrics.count("sams.league_matches.empty_response", 1, {
+            attributes: {
+              page: String(currentPage),
+              sportsclub_uuid: sportsclubUuid ?? "",
+              league: league ?? "",
+              season: season ?? "",
+              team: team ?? "",
+            },
+          });
+        }
         break;
       }
 


### PR DESCRIPTION
Detect production from hostname/domain when CDK_ENVIRONMENT is missing in the client bundle, and log plus metric instead of throwing when league matches return no data.