### PR TITLE
Fix mail forwarding MIME headers and proxy alias domain inference

### DIFF
--- a/app/src/server/functions/member-alias.test.ts
+++ b/app/src/server/functions/member-alias.test.ts
@@ -112,6 +112,12 @@ describe("proxy alias environment helpers", () => {
     expect(getProxyAliasDomain("prod", "dev.new.vcmuellheim.de")).toBe("new.vcmuellheim.de");
   });
 
+  test("keeps branch suffix on dev domain when build-time env is prod", () => {
+    expect(getProxyAliasBranchName("prod", "email-proxy", "new.vcmuellheim.de")).toBe(
+      "email-proxy",
+    );
+  });
+
   test("hides branch suffix on production recipient domains", () => {
     expect(isProdProxyAliasDomain("vcmuellheim.de")).toBe(true);
     expect(getProxyAliasBranchName("dev", "main", "vcmuellheim.de")).toBeUndefined();

--- a/app/src/server/functions/member-alias.test.ts
+++ b/app/src/server/functions/member-alias.test.ts
@@ -91,10 +91,25 @@ describe("proxy alias environment helpers", () => {
     expect(getProxyAliasBranchName("dev", "email-proxy")).toBe("email-proxy");
   });
 
-  test("infers production domain from hostname when build-time env is missing", () => {
-    expect(getProxyAliasDomain(undefined, "vcmuellheim.de")).toBe("vcmuellheim.de");
-    expect(getProxyAliasDomain(undefined, "www.vcmuellheim.de")).toBe("vcmuellheim.de");
-    expect(getProxyAliasDomain(undefined, "dev.new.vcmuellheim.de")).toBe("new.vcmuellheim.de");
+  test("infers recipient domain from hostname when build-time env is missing", () => {
+    const previousEnvironment = process.env.CDK_ENVIRONMENT;
+    delete process.env.CDK_ENVIRONMENT;
+
+    try {
+      expect(getProxyAliasDomain(undefined, "vcmuellheim.de")).toBe("vcmuellheim.de");
+      expect(getProxyAliasDomain(undefined, "www.vcmuellheim.de")).toBe("vcmuellheim.de");
+      expect(getProxyAliasDomain(undefined, "dev.new.vcmuellheim.de")).toBe("new.vcmuellheim.de");
+    } finally {
+      if (previousEnvironment === undefined) {
+        delete process.env.CDK_ENVIRONMENT;
+      } else {
+        process.env.CDK_ENVIRONMENT = previousEnvironment;
+      }
+    }
+  });
+
+  test("prefers dev hostname over build-time prod env", () => {
+    expect(getProxyAliasDomain("prod", "dev.new.vcmuellheim.de")).toBe("new.vcmuellheim.de");
   });
 
   test("hides branch suffix on production recipient domains", () => {

--- a/app/src/server/functions/member-alias.test.ts
+++ b/app/src/server/functions/member-alias.test.ts
@@ -73,6 +73,12 @@ describe("suggestProxyAlias", () => {
     );
   });
 
+  test("sanitizes slashes in branch names for valid plus-address suffixes", () => {
+    expect(suggestProxyAlias("Julia Fischer", "new.vcmuellheim.de", "terijaki/f3ed6e0f")).toBe(
+      "julia.fischer+terijaki-f3ed6e0f@new.vcmuellheim.de",
+    );
+  });
+
   test("applies duplicate numbering before the branch suffix", () => {
     expect(suggestProxyAlias("Max Müller", "new.vcmuellheim.de", "email-proxy", 2)).toBe(
       "max.mueller2+email-proxy@new.vcmuellheim.de",
@@ -115,6 +121,12 @@ describe("proxy alias environment helpers", () => {
   test("keeps branch suffix on dev domain when build-time env is prod", () => {
     expect(getProxyAliasBranchName("prod", "email-proxy", "new.vcmuellheim.de")).toBe(
       "email-proxy",
+    );
+  });
+
+  test("sanitizes slashes in raw branch names for alias suffixes", () => {
+    expect(getProxyAliasBranchName("dev", "terijaki/f3ed6e0f", "new.vcmuellheim.de")).toBe(
+      "terijaki-f3ed6e0f",
     );
   });
 
@@ -165,5 +177,15 @@ describe("canonicalizeProxyAlias", () => {
     expect(
       canonicalizeProxyAlias("max.mueller+email-proxy@vcmuellheim.de", "prod", "email-proxy"),
     ).toBe("max.mueller@vcmuellheim.de");
+  });
+
+  test("rewrites unsanitized branch suffix to sanitized form in dev", () => {
+    expect(
+      canonicalizeProxyAlias(
+        "julia.fischer+terijaki/f3ed6e0f@new.vcmuellheim.de",
+        "dev",
+        "terijaki/f3ed6e0f",
+      ),
+    ).toBe("julia.fischer+terijaki-f3ed6e0f@new.vcmuellheim.de");
   });
 });

--- a/app/src/server/functions/member-alias.ts
+++ b/app/src/server/functions/member-alias.ts
@@ -6,6 +6,7 @@
  */
 
 import { Mail } from "@/project.config";
+import { sanitizeBranchName } from "@utils/git";
 
 /** Map of German special characters to ASCII equivalents */
 const GERMAN_CHAR_MAP: Record<string, string> = {
@@ -38,7 +39,8 @@ export function normalizeAliasLocalPart(name: string): string {
 }
 
 export function formatProxyAlias(localPart: string, domain: string, branchName?: string): string {
-  const suffix = branchName ? `+${branchName}` : "";
+  const sanitizedBranchName = branchName ? sanitizeBranchName(branchName) : "";
+  const suffix = sanitizedBranchName ? `+${sanitizedBranchName}` : "";
   return `${localPart}${suffix}@${domain}`;
 }
 
@@ -130,5 +132,10 @@ export function getProxyAliasBranchName(
     return undefined;
   }
 
-  return branchName;
+  const sanitizedBranchName = sanitizeBranchName(branchName);
+  if (!sanitizedBranchName || sanitizedBranchName === "main") {
+    return undefined;
+  }
+
+  return sanitizedBranchName;
 }

--- a/app/src/server/functions/member-alias.ts
+++ b/app/src/server/functions/member-alias.ts
@@ -87,23 +87,29 @@ export function isProdProxyAliasDomain(domain: string): boolean {
   return domain === Mail.prod.recipientDomain;
 }
 
-export function getProxyAliasDomain(
-  cdkEnvironment = process.env.CDK_ENVIRONMENT,
-  hostname?: string,
-): string {
-  if (cdkEnvironment === "prod" || isProdProxyAliasHostname(hostname)) {
+export function getProxyAliasDomain(cdkEnvironment?: string, hostname?: string): string {
+  if (hostname && isProdProxyAliasHostname(hostname)) {
+    return Mail.prod.recipientDomain;
+  }
+
+  if (hostname && isDevProxyAliasHostname(hostname)) {
+    return Mail.dev.recipientDomain;
+  }
+
+  const resolvedEnvironment = cdkEnvironment ?? process.env.CDK_ENVIRONMENT;
+  if (resolvedEnvironment === "prod") {
     return Mail.prod.recipientDomain;
   }
 
   return Mail.dev.recipientDomain;
 }
 
-function isProdProxyAliasHostname(hostname?: string): boolean {
-  if (!hostname) {
-    return false;
-  }
-
+function isProdProxyAliasHostname(hostname: string): boolean {
   return hostname === Mail.prod.recipientDomain || hostname === `www.${Mail.prod.recipientDomain}`;
+}
+
+function isDevProxyAliasHostname(hostname: string): boolean {
+  return hostname === Mail.dev.recipientDomain || hostname.endsWith(`.${Mail.dev.recipientDomain}`);
 }
 
 export function getProxyAliasBranchName(

--- a/app/src/server/functions/member-alias.ts
+++ b/app/src/server/functions/member-alias.ts
@@ -113,11 +113,16 @@ function isDevProxyAliasHostname(hostname: string): boolean {
 }
 
 export function getProxyAliasBranchName(
-  cdkEnvironment = process.env.CDK_ENVIRONMENT,
+  cdkEnvironment?: string,
   branchName = process.env.BRANCH_NAME,
   domain?: string,
 ): string | undefined {
-  if (cdkEnvironment === "prod" || (domain && isProdProxyAliasDomain(domain))) {
+  const resolvedEnvironment = cdkEnvironment ?? process.env.CDK_ENVIRONMENT;
+  const isProdContext =
+    (domain !== undefined && isProdProxyAliasDomain(domain)) ||
+    (domain === undefined && resolvedEnvironment === "prod");
+
+  if (isProdContext) {
     return undefined;
   }
 

--- a/lambda/mail/mail-forward.test.ts
+++ b/lambda/mail/mail-forward.test.ts
@@ -379,7 +379,129 @@ describe("mail-forward Lambda", () => {
       expect(rawMime).toMatch(
         /^From: "original\.sender \(original\.sender@example\.com\)" <postmaster@vcmuellheim\.de>$/im,
       );
-      expect(rawMime).toMatch(/Reply-To:.*original\.sender@example\.com/i);
+      expect(rawMime).toMatch(/^Reply-To: original\.sender@example\.com$/im);
+    });
+
+    test("quotes Reply-To display name when sender name contains comma", async () => {
+      mockByProxyEmailGo.mockResolvedValue({
+        data: [
+          {
+            id: "m1",
+            proxyEmail: "max.mustermann@vcmuellheim.de",
+            privateEmail: "max@example.com",
+          },
+        ],
+      });
+      s3Mock.on(GetObjectCommand).resolves({
+        Body: {
+          transformToString: vi
+            .fn()
+            .mockResolvedValue(
+              makeMime(
+                "max.mustermann@vcmuellheim.de",
+                "Volleyball Team, Muellheim <sender@example.com>",
+              ),
+            ),
+        } as never,
+      });
+
+      await handler(makeEvent("emails/reply-to-comma-test.eml"), mockLambdaContext as never);
+
+      const rawMime = Buffer.from(
+        getForwardCalls()[0].args[0].input.Content!.Raw!.Data!,
+      ).toString();
+      expect(rawMime).toMatch(/^Reply-To: "Volleyball Team, Muellheim" <sender@example\.com>$/im);
+    });
+
+    test("replaces existing Reply-To header with sanitized original sender", async () => {
+      mockByProxyEmailGo.mockResolvedValue({
+        data: [
+          {
+            id: "m1",
+            proxyEmail: "max.mustermann@vcmuellheim.de",
+            privateEmail: "max@example.com",
+          },
+        ],
+      });
+      s3Mock.on(GetObjectCommand).resolves({
+        Body: {
+          transformToString: vi
+            .fn()
+            .mockResolvedValue(
+              [
+                "From: sender@example.com",
+                "To: max.mustermann@vcmuellheim.de",
+                "Reply-To: broken reply <broken@example.com>",
+                "Subject: Test",
+                "",
+                "Hello world",
+              ].join("\n"),
+            ),
+        } as never,
+      });
+
+      await handler(makeEvent("emails/replace-reply-to-test.eml"), mockLambdaContext as never);
+
+      const rawMime = Buffer.from(
+        getForwardCalls()[0].args[0].input.Content!.Raw!.Data!,
+      ).toString();
+      expect(rawMime).not.toMatch(/^Reply-To: broken reply/im);
+      expect(rawMime).toMatch(/^Reply-To: sender@example\.com$/im);
+    });
+
+    test("strips Cc and Bcc headers before forwarding", async () => {
+      mockByProxyEmailGo.mockResolvedValue({
+        data: [
+          {
+            id: "m1",
+            proxyEmail: "max.mustermann@vcmuellheim.de",
+            privateEmail: "max@example.com",
+          },
+        ],
+      });
+      s3Mock.on(GetObjectCommand).resolves({
+        Body: {
+          transformToString: vi
+            .fn()
+            .mockResolvedValue(
+              [
+                "From: sender@example.com",
+                "To: max.mustermann@vcmuellheim.de",
+                "Cc: cc@example.com",
+                "Bcc: bcc@example.com",
+                "Subject: Test",
+                "",
+                "Hello world",
+              ].join("\n"),
+            ),
+        } as never,
+      });
+
+      await handler(makeEvent("emails/strip-cc-bcc-test.eml"), mockLambdaContext as never);
+
+      const rawMime = Buffer.from(
+        getForwardCalls()[0].args[0].input.Content!.Raw!.Data!,
+      ).toString();
+      expect(rawMime).not.toMatch(/^Cc:/im);
+      expect(rawMime).not.toMatch(/^Bcc:/im);
+    });
+
+    test("trims whitespace from destination email address", async () => {
+      mockByProxyEmailGo.mockResolvedValue({
+        data: [
+          {
+            id: "m1",
+            proxyEmail: "max.mustermann@vcmuellheim.de",
+            privateEmail: " max@example.com ",
+          },
+        ],
+      });
+
+      await handler(makeEvent("emails/trim-target-test.eml"), mockLambdaContext as never);
+
+      const sesCalls = getForwardCalls();
+      expect(sesCalls).toHaveLength(1);
+      expect(sesCalls[0].args[0].input.Destination?.ToAddresses).toEqual(["max@example.com"]);
     });
 
     test("includes original name and email in From display name", async () => {
@@ -415,6 +537,7 @@ describe("mail-forward Lambda", () => {
       );
       expect(rawMime).toMatch(/Reply-To:.*"Max Mustermann" <max\.mustermann@example\.com>/i);
     });
+
     test("forwards to all matching To addresses in a single email", async () => {
       s3Mock.on(GetObjectCommand).resolves({
         Body: {

--- a/lambda/mail/mail-forward.ts
+++ b/lambda/mail/mail-forward.ts
@@ -200,16 +200,14 @@ function parseOriginalSender(originalFrom: string): ParsedOriginalSender {
   const bareAddressMatch = normalizedOriginalFrom.match(
     /(^|\s|"|'|\()([^\s<>]+@[^\s<>]+)(?=$|\s|"|'|\))/,
   );
-  const originalEmail = (
-    angleAddressMatch?.[1] ||
-    bareAddressMatch?.[2] ||
-    UNKNOWN_SENDER_PLACEHOLDER_EMAIL
-  ).trim();
+  const originalEmail = sanitizeEmailAddress(
+    (angleAddressMatch?.[1] || bareAddressMatch?.[2] || UNKNOWN_SENDER_PLACEHOLDER_EMAIL).trim(),
+  );
 
   let originalName = "";
   if (angleAddressMatch) {
     const beforeAddress = normalizedOriginalFrom.slice(0, angleAddressMatch.index).trim();
-    originalName = beforeAddress.replace(/^"|"$/g, "").trim();
+    originalName = sanitizeHeaderDisplayText(beforeAddress.replace(/^"|"$/g, "").trim());
   }
   if (!originalName) {
     originalName = originalEmail.split("@")[0] || "unknown";
@@ -219,6 +217,37 @@ function parseOriginalSender(originalFrom: string): ParsedOriginalSender {
     name: originalName,
     email: originalEmail,
   };
+}
+
+function stripControlCharacters(value: string): string {
+  let stripped = "";
+  for (const char of value) {
+    const code = char.charCodeAt(0);
+    if (code >= 0x20 && code !== 0x7f) {
+      stripped += char;
+    }
+  }
+  return stripped;
+}
+
+function sanitizeHeaderDisplayText(value: string): string {
+  return stripControlCharacters(value).trim();
+}
+
+function sanitizeEmailAddress(email: string): string {
+  return stripControlCharacters(email).trim();
+}
+
+function formatMailboxHeaderValue(name: string, email: string): string {
+  const sanitizedEmail = sanitizeEmailAddress(email);
+  const sanitizedName = sanitizeHeaderDisplayText(name);
+
+  if (!sanitizedName || sanitizedName === sanitizedEmail.split("@")[0]) {
+    return sanitizedEmail;
+  }
+
+  const escapedName = sanitizedName.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  return `"${escapedName}" <${sanitizedEmail}>`;
 }
 
 function canNotifySender(senderEmail: string): boolean {
@@ -316,7 +345,7 @@ function splitMimeIntoHeadersAndBody(rawMime: string): { headers: string; body: 
 }
 
 const BLOCKED_FORWARD_HEADER_PATTERN =
-  /^(return-path|sender|dkim-signature|arc-seal|arc-message-signature|arc-authentication-results|authentication-results|received-spf):/i;
+  /^(return-path|sender|dkim-signature|arc-seal|arc-message-signature|arc-authentication-results|authentication-results|received-spf|reply-to|cc|bcc|disposition-notification-to|return-receipt-to|x-original-to):/i;
 
 function stripBlockedForwardHeaders(headers: string): string {
   const headerLines = headers.split(/\r?\n/);
@@ -343,8 +372,15 @@ function stripBlockedForwardHeaders(headers: string): string {
 function buildForwardFromHeaderValue(originalFrom: string, newFrom: string): string {
   const sender = parseOriginalSender(originalFrom);
   const fromDisplayText = `${sender.name} (${sender.email})`;
-  const escapedFromDisplayText = fromDisplayText.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
-  return `"${escapedFromDisplayText}" <${newFrom}>`;
+  const escapedFromDisplayText = sanitizeHeaderDisplayText(fromDisplayText)
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"');
+  return `"${escapedFromDisplayText}" <${sanitizeEmailAddress(newFrom)}>`;
+}
+
+function buildReplyToHeaderValue(originalFrom: string): string {
+  const sender = parseOriginalSender(originalFrom);
+  return formatMailboxHeaderValue(sender.name, sender.email);
 }
 
 function applyForwardingHeaderRewrites(
@@ -353,18 +389,16 @@ function applyForwardingHeaderRewrites(
   rewrittenFrom: string,
   newTo: string,
 ): string {
-  let rewritten = headers
+  const sanitizedTo = sanitizeEmailAddress(newTo);
+  const replyTo = buildReplyToHeaderValue(originalFrom);
+
+  const rewritten = headers
     // Replace From header
     .replace(/^from:.*$/im, `From: ${rewrittenFrom}`)
     // Replace To header
-    .replace(/^to:.*$/im, `To: ${newTo}`);
+    .replace(/^to:.*$/im, `To: ${sanitizedTo}`);
 
-  // Add Reply-To header if not already present
-  if (!/^reply-to:/im.test(rewritten)) {
-    rewritten += `\r\nReply-To: ${originalFrom}`;
-  }
-
-  return rewritten;
+  return `${rewritten}\r\nReply-To: ${replyTo}`;
 }
 
 /**
@@ -405,14 +439,15 @@ function extractFromAddress(rawMime: string): string {
 
 async function sendForwardedEmail(input: SendForwardedEmailInput): Promise<ForwardSendResult> {
   const { rawMime, originalFrom, newFrom, target, s3Key, errorContext } = input;
+  const sanitizedTarget = sanitizeEmailAddress(target);
 
   try {
-    const rewritten = rewriteMimeHeaders(rawMime, originalFrom, newFrom, target);
+    const rewritten = rewriteMimeHeaders(rawMime, originalFrom, newFrom, sanitizedTarget);
     await ses.send(
       new SendEmailCommand({
         FromEmailAddress: newFrom,
         Destination: {
-          ToAddresses: [target],
+          ToAddresses: [sanitizedTarget],
         },
         Content: {
           Raw: {

--- a/utils/git.test.ts
+++ b/utils/git.test.ts
@@ -1,12 +1,18 @@
 import { execSync } from "node:child_process";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
-import { getSanitizedBranch } from "./git";
+import { getSanitizedBranch, sanitizeBranchName } from "./git";
 
 vi.mock("node:child_process", () => ({
   execSync: vi.fn(),
 }));
 
 const mockExecSync = vi.mocked(execSync);
+
+describe("sanitizeBranchName", () => {
+  it("replaces slashes with hyphens", () => {
+    expect(sanitizeBranchName("terijaki/f3ed6e0f")).toBe("terijaki-f3ed6e0f");
+  });
+});
 
 describe("getSanitizedBranch", () => {
   beforeEach(() => {

--- a/utils/git.ts
+++ b/utils/git.ts
@@ -1,6 +1,21 @@
 import { execSync } from "node:child_process";
 
 /**
+ * Sanitize a branch name for use in AWS resource names and email plus-address suffixes.
+ * Lowercases, replaces non-alphanumeric characters with hyphens, and truncates to 20 chars.
+ */
+export function sanitizeBranchName(branch: string): string {
+  return branch
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+/, "")
+    .replace(/-+$/, "")
+    .substring(0, 20)
+    .replace(/-+$/, "");
+}
+
+/**
  * Get current Git branch name, sanitized for AWS resource naming.
  * Returns empty string if on main branch or if Git is unavailable.
  * Sanitization: alphanumeric and hyphens only, max 20 chars.
@@ -18,15 +33,7 @@ export function getSanitizedBranch(includeMain = false): string {
       return "";
     }
 
-    // Sanitize: alphanumeric and hyphens only, max 20 chars, no leading/trailing hyphens
-    return branch
-      .toLowerCase()
-      .replace(/[^a-z0-9-]/g, "-")
-      .replace(/-+/g, "-")
-      .replace(/^-+/, "")
-      .replace(/-+$/, "")
-      .substring(0, 20)
-      .replace(/-+$/, ""); // Remove trailing hyphen if substring created one
+    return sanitizeBranchName(branch);
   } catch {
     return "";
   }


### PR DESCRIPTION
## Summary
- Sanitize forwarded MIME headers in the mail-forward Lambda so SES no longer rejects messages with unquoted sender display names, leftover Cc/Bcc headers, or whitespace in destination addresses
- Fix proxy alias domain inference to prefer hostname-based prod/dev detection before `CDK_ENVIRONMENT`, so dev subdomains like `dev.new.vcmuellheim.de` resolve correctly in CI

Fixes VOLLEYBALL-WEBSITE-68
Fixes VOLLEYBALL-WEBSITE-6B

## Test plan
- [x] `vp test lambda/mail/mail-forward.test.ts` (24 tests pass)
- [x] `vp test app/src/server/functions/member-alias.test.ts` (24 tests pass, including with `CDK_ENVIRONMENT=prod`)
- [ ] Deploy mail-forward Lambda to prod and verify group/individual forwarding succeeds