### PR TITLE
Fix mail forwarding SES rejections and harden MIME header handling.

### DIFF
--- a/lambda/mail/mail-forward.test.ts
+++ b/lambda/mail/mail-forward.test.ts
@@ -673,6 +673,99 @@ describe("mail-forward Lambda", () => {
       expect(rawMime).toMatch(/^Reply-To: =\?UTF-8\?Q\?M=C3=BCller\?= <mueller@gmx\.de>$/im);
     });
 
+    test("sanitizes angle address in preserved RFC 2047 Reply-To", async () => {
+      mockByProxyEmailGo.mockResolvedValue({
+        data: [
+          {
+            id: "m1",
+            proxyEmail: "max.mustermann@vcmuellheim.de",
+            privateEmail: "max@example.com",
+          },
+        ],
+      });
+      s3Mock.on(GetObjectCommand).resolves({
+        Body: {
+          transformToString: vi
+            .fn()
+            .mockResolvedValue(
+              makeMime(
+                "max.mustermann@vcmuellheim.de",
+                "=?UTF-8?Q?M=C3=BCller?= <mueller @gmx.de>",
+              ),
+            ),
+        } as never,
+      });
+
+      await handler(makeEvent("emails/rfc2047-reply-to-sanitize.eml"), mockLambdaContext as never);
+
+      const rawMime = Buffer.from(
+        getForwardCalls()[0].args[0].input.Content!.Raw!.Data!,
+      ).toString();
+      expect(rawMime).toMatch(/^Reply-To: =\?UTF-8\?Q\?M=C3=BCller\?= <mueller@gmx\.de>$/im);
+    });
+
+    test("RFC 2047-encodes question marks in display names", async () => {
+      mockByProxyEmailGo.mockResolvedValue({
+        data: [
+          {
+            id: "m1",
+            proxyEmail: "max.mustermann@vcmuellheim.de",
+            privateEmail: "max@example.com",
+          },
+        ],
+      });
+      s3Mock.on(GetObjectCommand).resolves({
+        Body: {
+          transformToString: vi
+            .fn()
+            .mockResolvedValue(
+              makeMime("max.mustermann@vcmuellheim.de", "Müller? <sender@example.com>"),
+            ),
+        } as never,
+      });
+
+      await handler(makeEvent("emails/question-mark-reply-to.eml"), mockLambdaContext as never);
+
+      const rawMime = Buffer.from(
+        getForwardCalls()[0].args[0].input.Content!.Raw!.Data!,
+      ).toString();
+      expect(rawMime).toMatch(/^Reply-To: =\?UTF-8\?Q\?M=C3=BCller=3F\?= <sender@example\.com>$/im);
+    });
+
+    test("splits long non-ASCII display names into multiple RFC 2047 encoded-words", async () => {
+      const longName = "Müller ".repeat(12).trim();
+      mockByProxyEmailGo.mockResolvedValue({
+        data: [
+          {
+            id: "m1",
+            proxyEmail: "max.mustermann@vcmuellheim.de",
+            privateEmail: "max@example.com",
+          },
+        ],
+      });
+      s3Mock.on(GetObjectCommand).resolves({
+        Body: {
+          transformToString: vi
+            .fn()
+            .mockResolvedValue(
+              makeMime("max.mustermann@vcmuellheim.de", `${longName} <sender@example.com>`),
+            ),
+        } as never,
+      });
+
+      await handler(makeEvent("emails/long-unicode-reply-to.eml"), mockLambdaContext as never);
+
+      const rawMime = Buffer.from(
+        getForwardCalls()[0].args[0].input.Content!.Raw!.Data!,
+      ).toString();
+      const replyToLine = rawMime.match(/^Reply-To: (.+)$/im)?.[1] ?? "";
+      const encodedWords = replyToLine.match(/=\?UTF-8\?Q\?[^?]+\?=/g) ?? [];
+      expect(encodedWords.length).toBeGreaterThan(1);
+      for (const word of encodedWords) {
+        expect(word.length).toBeLessThanOrEqual(75);
+      }
+    });
+
     test("RFC 2047-encodes non-ASCII sender names when rebuilding Reply-To", async () => {
       mockByProxyEmailGo.mockResolvedValue({
         data: [
@@ -999,6 +1092,31 @@ describe("mail-forward Lambda", () => {
       expect(destinations).toContain("trainer1@example.com");
       expect(destinations).toContain("trainer2@example.com");
       expect(result).toMatchObject({ statusCode: 200, body: "forwarded: 2" });
+    });
+
+    test("deduplicates group members after email sanitization", async () => {
+      s3Mock.on(GetObjectCommand).resolves({
+        Body: {
+          transformToString: vi.fn().mockResolvedValue(makeMime("trainer@vcmuellheim.de")),
+        } as never,
+      });
+      mockByTypeWhereGo.mockResolvedValue({
+        data: [
+          { id: "t1", isTrainer: true, privateEmail: "trainer1@example.com" },
+          { id: "t2", isTrainer: true, privateEmail: "trainer1 @example.com" },
+        ],
+      });
+
+      const result = await handler(
+        makeEvent("emails/trainer-dedupe-sanitize.eml"),
+        mockLambdaContext as never,
+      );
+
+      expect(getForwardCalls()).toHaveLength(1);
+      expect(getForwardCalls()[0].args[0].input.Destination?.ToAddresses).toEqual([
+        "trainer1@example.com",
+      ]);
+      expect(result).toMatchObject({ statusCode: 200, body: "forwarded: 1" });
     });
 
     test("forwards vorstand@ to all board members with a privateEmail", async () => {

--- a/lambda/mail/mail-forward.test.ts
+++ b/lambda/mail/mail-forward.test.ts
@@ -14,6 +14,7 @@ import { GetObjectCommand, S3Client } from "@aws-sdk/client-s3";
 import { SESv2Client, SendEmailCommand } from "@aws-sdk/client-sesv2";
 import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
 import { mockClient } from "aws-sdk-client-mock";
+import { Sentry } from "../utils/sentry";
 
 // ── Environment setup (must happen before module import) ─────────────────────
 process.env.CONTENT_TABLE_NAME = "test-content-table";
@@ -132,6 +133,7 @@ describe("mail-forward Lambda", () => {
 
     const mod = await import("./mail-forward");
     handler = mod.handler as unknown as (event: unknown, context: unknown) => Promise<unknown>;
+    vi.mocked(Sentry.captureException).mockClear();
   });
 
   describe("unknown alias", () => {
@@ -199,9 +201,7 @@ describe("mail-forward Lambda", () => {
       const rawMime = Buffer.from(
         getForwardCalls()[0].args[0].input.Content!.Raw!.Data!,
       ).toString();
-      expect(rawMime).toMatch(
-        /^From: "sender \(sender@example\.com\)" <postmaster@vcmuellheim\.de>$/im,
-      );
+      expect(rawMime).toMatch(/^From: postmaster@vcmuellheim\.de$/im);
     });
 
     test("removes DKIM-Signature headers before forwarding", async () => {
@@ -274,9 +274,7 @@ describe("mail-forward Lambda", () => {
         getForwardCalls()[0].args[0].input.Content!.Raw!.Data!,
       ).toString();
       expect(rawMime).not.toMatch(/^Return-Path:/im);
-      expect(rawMime).toMatch(
-        /^From: "mail \(mail@example\.com\)" <postmaster@vcmuellheim\.de>$/im,
-      );
+      expect(rawMime).toMatch(/^From: postmaster@vcmuellheim\.de$/im);
     });
 
     test("in dev, looks up DDB with the full plus-address (suffix included)", async () => {
@@ -376,9 +374,7 @@ describe("mail-forward Lambda", () => {
       const rawMime = Buffer.from(
         getForwardCalls()[0].args[0].input.Content!.Raw!.Data!,
       ).toString();
-      expect(rawMime).toMatch(
-        /^From: "original\.sender \(original\.sender@example\.com\)" <postmaster@vcmuellheim\.de>$/im,
-      );
+      expect(rawMime).toMatch(/^From: postmaster@vcmuellheim\.de$/im);
       expect(rawMime).toMatch(/^Reply-To: original\.sender@example\.com$/im);
     });
 
@@ -504,7 +500,119 @@ describe("mail-forward Lambda", () => {
       expect(sesCalls[0].args[0].input.Destination?.ToAddresses).toEqual(["max@example.com"]);
     });
 
-    test("includes original name and email in From display name", async () => {
+    test("strips internal whitespace from destination email address", async () => {
+      mockByProxyEmailGo.mockResolvedValue({
+        data: [
+          {
+            id: "m1",
+            proxyEmail: "max.mustermann@vcmuellheim.de",
+            privateEmail: "max @example.com",
+          },
+        ],
+      });
+
+      await handler(makeEvent("emails/internal-whitespace-target.eml"), mockLambdaContext as never);
+
+      const sesCalls = getForwardCalls();
+      expect(sesCalls).toHaveLength(1);
+      expect(sesCalls[0].args[0].input.Destination?.ToAddresses).toEqual(["max@example.com"]);
+    });
+
+    test("strips folded To header continuations after rewrite", async () => {
+      mockByProxyEmailGo.mockResolvedValue({
+        data: [
+          {
+            id: "m1",
+            proxyEmail: "max.mustermann@vcmuellheim.de",
+            privateEmail: "max@example.com",
+          },
+        ],
+      });
+      s3Mock.on(GetObjectCommand).resolves({
+        Body: {
+          transformToString: vi
+            .fn()
+            .mockResolvedValue(
+              [
+                "From: sender@example.com",
+                "To: other@example.com,",
+                " max.mustermann@vcmuellheim.de",
+                "Subject: Test",
+                "",
+                "Hello world",
+              ].join("\n"),
+            ),
+        } as never,
+      });
+
+      await handler(makeEvent("emails/folded-to-test.eml"), mockLambdaContext as never);
+
+      const rawMime = Buffer.from(
+        getForwardCalls()[0].args[0].input.Content!.Raw!.Data!,
+      ).toString();
+      expect(rawMime).toMatch(/^To: max@example\.com$/im);
+      expect(rawMime).not.toMatch(/other@example\.com/im);
+    });
+
+    test("skips member with invalid privateEmail and forwards to valid ones", async () => {
+      mockByProxyEmailGo.mockResolvedValue({
+        data: [
+          {
+            id: "m1",
+            proxyEmail: "max.mustermann@vcmuellheim.de",
+            privateEmail: "not-an-email",
+          },
+        ],
+      });
+
+      const result = await handler(
+        makeEvent("emails/invalid-private-email.eml"),
+        mockLambdaContext as never,
+      );
+
+      expect(getForwardCalls()).toHaveLength(0);
+      expect(result).toMatchObject({ statusCode: 200, body: expect.stringContaining("dropped") });
+    });
+
+    test("reports SES header context to Sentry on forward failure", async () => {
+      mockByProxyEmailGo.mockResolvedValue({
+        data: [
+          {
+            id: "m1",
+            proxyEmail: "max.mustermann@vcmuellheim.de",
+            privateEmail: "max@example.com",
+          },
+        ],
+      });
+      s3Mock.on(GetObjectCommand).resolves({
+        Body: {
+          transformToString: vi
+            .fn()
+            .mockResolvedValue(
+              makeMime("max.mustermann@vcmuellheim.de", '"Max Mustermann" <sender@example.com>'),
+            ),
+        } as never,
+      });
+      sesMock.on(SendEmailCommand).rejects(new Error("Domain contains control or whitespace"));
+
+      await expect(
+        handler(makeEvent("emails/sentry-context-test.eml"), mockLambdaContext as never),
+      ).rejects.toThrow("All forwards failed");
+
+      expect(Sentry.captureException).toHaveBeenCalledWith(
+        expect.any(Error),
+        expect.objectContaining({
+          extra: expect.objectContaining({
+            originalFrom: '"Max Mustermann" <sender@example.com>',
+            rewrittenFrom: expect.stringContaining("postmaster@vcmuellheim.de"),
+            replyTo: expect.stringContaining("sender@example.com"),
+            target: "max@example.com",
+          }),
+        }),
+      );
+    });
+
+    test("includes original sender name in From display name", async () => {
       mockByProxyEmailGo.mockResolvedValue({
         data: [
           {
@@ -532,10 +640,82 @@ describe("mail-forward Lambda", () => {
       const rawMime = Buffer.from(
         getForwardCalls()[0].args[0].input.Content!.Raw!.Data!,
       ).toString();
-      expect(rawMime).toMatch(
-        /^From: "Max Mustermann \(max\.mustermann@example\.com\)" <postmaster@vcmuellheim\.de>$/im,
-      );
-      expect(rawMime).toMatch(/Reply-To:.*"Max Mustermann" <max\.mustermann@example\.com>/i);
+      expect(rawMime).toMatch(/^From: "Max Mustermann" <postmaster@vcmuellheim\.de>$/im);
+      expect(rawMime).toMatch(/^Reply-To: "Max Mustermann" <max\.mustermann@example\.com>$/im);
+    });
+
+    test("preserves RFC 2047 encoded sender name in forwarded headers", async () => {
+      mockByProxyEmailGo.mockResolvedValue({
+        data: [
+          {
+            id: "m1",
+            proxyEmail: "max.mustermann@vcmuellheim.de",
+            privateEmail: "max@example.com",
+          },
+        ],
+      });
+      s3Mock.on(GetObjectCommand).resolves({
+        Body: {
+          transformToString: vi
+            .fn()
+            .mockResolvedValue(
+              makeMime("max.mustermann@vcmuellheim.de", "=?UTF-8?Q?M=C3=BCller?= <mueller@gmx.de>"),
+            ),
+        } as never,
+      });
+
+      await handler(makeEvent("emails/rfc2047-from-test.eml"), mockLambdaContext as never);
+
+      const rawMime = Buffer.from(
+        getForwardCalls()[0].args[0].input.Content!.Raw!.Data!,
+      ).toString();
+      expect(rawMime).toMatch(/^From: =\?UTF-8\?Q\?M=C3=BCller\?= <postmaster@vcmuellheim\.de>$/im);
+      expect(rawMime).toMatch(/^Reply-To: =\?UTF-8\?Q\?M=C3=BCller\?= <mueller@gmx\.de>$/im);
+    });
+
+    test("RFC 2047-encodes non-ASCII sender names when rebuilding Reply-To", async () => {
+      mockByProxyEmailGo.mockResolvedValue({
+        data: [
+          {
+            id: "m1",
+            proxyEmail: "max.mustermann@vcmuellheim.de",
+            privateEmail: "max@example.com",
+          },
+        ],
+      });
+      s3Mock.on(GetObjectCommand).resolves({
+        Body: {
+          transformToString: vi
+            .fn()
+            .mockResolvedValue(
+              makeMime("max.mustermann@vcmuellheim.de", "Müller <mueller@gmx.de>"),
+            ),
+        } as never,
+      });
+
+      await handler(makeEvent("emails/unicode-reply-to-test.eml"), mockLambdaContext as never);
+
+      const rawMime = Buffer.from(
+        getForwardCalls()[0].args[0].input.Content!.Raw!.Data!,
+      ).toString();
+      expect(rawMime).toMatch(/^From: =\?UTF-8\?Q\?M=C3=BCller\?= <postmaster@vcmuellheim\.de>$/im);
+      expect(rawMime).toMatch(/^Reply-To: =\?UTF-8\?Q\?M=C3=BCller\?= <mueller@gmx\.de>$/im);
+    });
+
+    test("sanitizes FromEmailAddress in SES API call", async () => {
+      mockByProxyEmailGo.mockResolvedValue({
+        data: [
+          {
+            id: "m1",
+            proxyEmail: "max.mustermann@vcmuellheim.de",
+            privateEmail: "max@example.com",
+          },
+        ],
+      });
+
+      await handler(makeEvent("emails/from-api-sanitize-test.eml"), mockLambdaContext as never);
+
+      expect(getForwardCalls()[0].args[0].input.FromEmailAddress).toBe("postmaster@vcmuellheim.de");
     });
 
     test("forwards to all matching To addresses in a single email", async () => {
@@ -819,6 +999,104 @@ describe("mail-forward Lambda", () => {
       expect(destinations).toContain("trainer1@example.com");
       expect(destinations).toContain("trainer2@example.com");
       expect(result).toMatchObject({ statusCode: 200, body: "forwarded: 2" });
+    });
+
+    test("forwards vorstand@ to all board members with a privateEmail", async () => {
+      s3Mock.on(GetObjectCommand).resolves({
+        Body: {
+          transformToString: vi.fn().mockResolvedValue(makeMime("vorstand@vcmuellheim.de")),
+        } as never,
+      });
+      mockByTypeWhereGo.mockResolvedValue({
+        data: [
+          { id: "b1", isBoardMember: true, privateEmail: "board1@example.com" },
+          { id: "b2", isBoardMember: true, privateEmail: "board2@example.com" },
+        ],
+      });
+
+      const result = await handler(
+        makeEvent("emails/vorstand-group.eml"),
+        mockLambdaContext as never,
+      );
+
+      const sesCalls = getForwardCalls();
+      expect(sesCalls).toHaveLength(2);
+      const destinations = sesCalls.map((c) => c.args[0].input.Destination!.ToAddresses![0]);
+      expect(destinations).toContain("board1@example.com");
+      expect(destinations).toContain("board2@example.com");
+      expect(result).toMatchObject({ statusCode: 200, body: "forwarded: 2" });
+    });
+
+    test("skips invalid group member emails and forwards to valid ones", async () => {
+      s3Mock.on(GetObjectCommand).resolves({
+        Body: {
+          transformToString: vi.fn().mockResolvedValue(makeMime("trainer@vcmuellheim.de")),
+        } as never,
+      });
+      mockByTypeWhereGo.mockResolvedValue({
+        data: [
+          { id: "t1", isTrainer: true, privateEmail: "trainer1@example.com" },
+          { id: "t2", isTrainer: true, privateEmail: "not-an-email" },
+        ],
+      });
+
+      const result = await handler(
+        makeEvent("emails/trainer-invalid-member.eml"),
+        mockLambdaContext as never,
+      );
+
+      const sesCalls = getForwardCalls();
+      expect(sesCalls).toHaveLength(1);
+      expect(sesCalls[0].args[0].input.Destination?.ToAddresses).toEqual(["trainer1@example.com"]);
+      expect(result).toMatchObject({ statusCode: 200, body: "forwarded: 1" });
+    });
+
+    test("returns partial success when some group forwards fail", async () => {
+      s3Mock.on(GetObjectCommand).resolves({
+        Body: {
+          transformToString: vi.fn().mockResolvedValue(makeMime("trainer@vcmuellheim.de")),
+        } as never,
+      });
+      mockByTypeWhereGo.mockResolvedValue({
+        data: [
+          { id: "t1", isTrainer: true, privateEmail: "fail@example.com" },
+          { id: "t2", isTrainer: true, privateEmail: "ok@example.com" },
+        ],
+      });
+      sesMock
+        .on(SendEmailCommand)
+        .rejectsOnce(new Error("Domain contains control or whitespace"))
+        .resolves({ MessageId: "test-message-id" });
+
+      const result = await handler(
+        makeEvent("emails/trainer-partial-failure.eml"),
+        mockLambdaContext as never,
+      );
+
+      expect(getForwardCalls()).toHaveLength(2);
+      expect(result).toMatchObject({ statusCode: 200, body: "forwarded: 1" });
+      expect(Sentry.captureException).toHaveBeenCalledTimes(1);
+    });
+
+    test("throws when all group forwards fail", async () => {
+      s3Mock.on(GetObjectCommand).resolves({
+        Body: {
+          transformToString: vi.fn().mockResolvedValue(makeMime("trainer@vcmuellheim.de")),
+        } as never,
+      });
+      mockByTypeWhereGo.mockResolvedValue({
+        data: [
+          { id: "t1", isTrainer: true, privateEmail: "fail1@example.com" },
+          { id: "t2", isTrainer: true, privateEmail: "fail2@example.com" },
+        ],
+      });
+      sesMock.on(SendEmailCommand).rejects(new Error("Domain contains control or whitespace"));
+
+      await expect(
+        handler(makeEvent("emails/trainer-all-fail.eml"), mockLambdaContext as never),
+      ).rejects.toThrow(
+        "All forwards failed: fail1@example.com: Domain contains control or whitespace",
+      );
     });
 
     test("info@ forwards to union of trainers and board members, deduplicated", async () => {

--- a/lambda/mail/mail-forward.ts
+++ b/lambda/mail/mail-forward.ts
@@ -236,6 +236,9 @@ function parseOriginalSender(originalFrom: string): ParsedOriginalSender {
 
 const INVISIBLE_EMAIL_CHARACTERS = ["\u00a0", "\u200b", "\u200c", "\u200d", "\ufeff"] as const;
 const RFC2047_ENCODED_WORD_PATTERN = /=\?[^?]+\?[BQbq]\?[^?]*\?=/;
+const RFC2047_MAX_ENCODED_WORD_LENGTH = 75;
+const RFC2047_ENCODED_WORD_PREFIX = "=?UTF-8?Q?";
+const RFC2047_ENCODED_WORD_SUFFIX = "?=";
 
 function stripInvisibleEmailCharacters(value: string): string {
   let stripped = value;
@@ -287,15 +290,15 @@ function collectRoutableEmails(
   entries: Array<{ email: string; memberId?: string }>,
   source: string,
 ): string[] {
-  const routable: string[] = [];
+  const routable = new Set<string>();
   for (const entry of entries) {
     const sanitized = sanitizeRoutableEmail(entry.email, {
       memberId: entry.memberId,
       source,
     });
-    if (sanitized) routable.push(sanitized);
+    if (sanitized) routable.add(sanitized);
   }
-  return routable;
+  return Array.from(routable);
 }
 
 function isRfc2047EncodedWord(value: string): boolean {
@@ -311,19 +314,50 @@ function containsNonAscii(value: string): boolean {
   return false;
 }
 
+function encodeQuotedPrintableByte(byte: number): string {
+  if (byte === 32) {
+    return "_";
+  }
+  if (byte === 63) {
+    return "=3F";
+  }
+  if ((byte >= 33 && byte <= 60) || (byte >= 62 && byte <= 126)) {
+    return String.fromCharCode(byte);
+  }
+  return `=${byte.toString(16).toUpperCase().padStart(2, "0")}`;
+}
+
+function wrapRfc2047EncodedWord(quotedPrintablePayload: string): string {
+  return `${RFC2047_ENCODED_WORD_PREFIX}${quotedPrintablePayload}${RFC2047_ENCODED_WORD_SUFFIX}`;
+}
+
 function encodeRfc2047Utf8(text: string): string {
   const bytes = new TextEncoder().encode(text);
-  let quotedPrintable = "";
+  const qpSegments: string[] = [];
   for (const byte of bytes) {
-    if (byte === 32) {
-      quotedPrintable += "_";
-    } else if ((byte >= 33 && byte <= 60) || (byte >= 62 && byte <= 126)) {
-      quotedPrintable += String.fromCharCode(byte);
-    } else {
-      quotedPrintable += `=${byte.toString(16).toUpperCase().padStart(2, "0")}`;
-    }
+    qpSegments.push(encodeQuotedPrintableByte(byte));
   }
-  return `=?UTF-8?Q?${quotedPrintable}?=`;
+
+  const words: string[] = [];
+  let current = "";
+  for (const segment of qpSegments) {
+    const candidate = current + segment;
+    if (wrapRfc2047EncodedWord(candidate).length <= RFC2047_MAX_ENCODED_WORD_LENGTH) {
+      current = candidate;
+      continue;
+    }
+
+    if (current.length > 0) {
+      words.push(wrapRfc2047EncodedWord(current));
+    }
+    current = segment;
+  }
+
+  if (current.length > 0) {
+    words.push(wrapRfc2047EncodedWord(current));
+  }
+
+  return words.join(" ");
 }
 
 function formatDisplayNameForHeader(displayName: string): string {
@@ -535,9 +569,28 @@ function buildForwardFromHeaderValue(originalFrom: string, newFrom: string): str
   return formatFromHeaderValue(sender.name, newFrom, sender.email);
 }
 
+function buildPreservedReplyToHeaderValue(originalFrom: string): string {
+  const normalized = originalFrom.replace(/\s+/g, " ").trim();
+  const sender = parseOriginalSender(originalFrom);
+  const angleAddressMatch = normalized.match(/<[^<>]+@[^<>]+>/);
+
+  if (!angleAddressMatch || angleAddressMatch.index === undefined) {
+    return formatMailboxHeaderValue(sender.name, sender.email);
+  }
+
+  const displayName = normalized.slice(0, angleAddressMatch.index).trim();
+  const sanitizedEmail = sanitizeEmailAddress(sender.email);
+
+  if (!displayName) {
+    return sanitizedEmail;
+  }
+
+  return `${displayName} <${sanitizedEmail}>`;
+}
+
 function buildReplyToHeaderValue(originalFrom: string): string {
   if (shouldPreserveReplyToHeader(originalFrom)) {
-    return originalFrom.replace(/\s+/g, " ").trim();
+    return buildPreservedReplyToHeaderValue(originalFrom);
   }
 
   const sender = parseOriginalSender(originalFrom);

--- a/lambda/mail/mail-forward.ts
+++ b/lambda/mail/mail-forward.ts
@@ -91,14 +91,24 @@ async function resolveGroupAlias(localPart: string): Promise<string[] | null> {
         .byType({ type: "member" })
         .where((attr, op) => op.eq(attr.isTrainer, true))
         .go({ pages: "all" });
-      return result.data.filter((m) => m.privateEmail).map((m) => m.privateEmail as string);
+      return collectRoutableEmails(
+        result.data
+          .filter((m) => m.privateEmail)
+          .map((m) => ({ email: m.privateEmail as string, memberId: m.id })),
+        "trainer",
+      );
     },
     vorstand: async () => {
       const result = await db.member.query
         .byType({ type: "member" })
         .where((attr, op) => op.eq(attr.isBoardMember, true))
         .go({ pages: "all" });
-      return result.data.filter((m) => m.privateEmail).map((m) => m.privateEmail as string);
+      return collectRoutableEmails(
+        result.data
+          .filter((m) => m.privateEmail)
+          .map((m) => ({ email: m.privateEmail as string, memberId: m.id })),
+        "vorstand",
+      );
     },
     info: async () => {
       // info@ routes to trainers + board members (union, deduplicated).
@@ -114,7 +124,12 @@ async function resolveGroupAlias(localPart: string): Promise<string[] | null> {
       ]);
       const emails = new Set<string>();
       for (const m of [...trainersResult.data, ...boardResult.data]) {
-        if (m.privateEmail) emails.add(m.privateEmail);
+        if (!m.privateEmail) continue;
+        const sanitized = sanitizeRoutableEmail(m.privateEmail, {
+          memberId: m.id,
+          source: "info",
+        });
+        if (sanitized) emails.add(sanitized);
       }
       return Array.from(emails);
     },
@@ -219,6 +234,17 @@ function parseOriginalSender(originalFrom: string): ParsedOriginalSender {
   };
 }
 
+const INVISIBLE_EMAIL_CHARACTERS = ["\u00a0", "\u200b", "\u200c", "\u200d", "\ufeff"] as const;
+const RFC2047_ENCODED_WORD_PATTERN = /=\?[^?]+\?[BQbq]\?[^?]*\?=/;
+
+function stripInvisibleEmailCharacters(value: string): string {
+  let stripped = value;
+  for (const char of INVISIBLE_EMAIL_CHARACTERS) {
+    stripped = stripped.split(char).join("");
+  }
+  return stripped;
+}
+
 function stripControlCharacters(value: string): string {
   let stripped = "";
   for (const char of value) {
@@ -231,27 +257,131 @@ function stripControlCharacters(value: string): string {
 }
 
 function sanitizeHeaderDisplayText(value: string): string {
-  return stripControlCharacters(value).trim();
+  return stripInvisibleEmailCharacters(stripControlCharacters(value)).trim();
 }
 
 function sanitizeEmailAddress(email: string): string {
-  return stripControlCharacters(email).trim();
+  const withoutControlChars = stripControlCharacters(email);
+  const withoutInvisibleChars = stripInvisibleEmailCharacters(withoutControlChars);
+  // SES rejects addresses with internal whitespace (not just leading/trailing).
+  return withoutInvisibleChars.replace(/[ \t]/g, "").trim();
+}
+
+function sanitizeRoutableEmail(
+  rawEmail: string,
+  context: { memberId?: string; source: string },
+): string | null {
+  const sanitized = sanitizeEmailAddress(rawEmail);
+  if (!BASIC_EMAIL_REGEX.test(sanitized)) {
+    logger.warn("Skipping unroutable email address", {
+      ...context,
+      rawEmail,
+      sanitizedEmail: sanitized,
+    });
+    return null;
+  }
+  return sanitized;
+}
+
+function collectRoutableEmails(
+  entries: Array<{ email: string; memberId?: string }>,
+  source: string,
+): string[] {
+  const routable: string[] = [];
+  for (const entry of entries) {
+    const sanitized = sanitizeRoutableEmail(entry.email, {
+      memberId: entry.memberId,
+      source,
+    });
+    if (sanitized) routable.push(sanitized);
+  }
+  return routable;
+}
+
+function isRfc2047EncodedWord(value: string): boolean {
+  return RFC2047_ENCODED_WORD_PATTERN.test(value);
+}
+
+function containsNonAscii(value: string): boolean {
+  for (const char of value) {
+    if (char.charCodeAt(0) > 127) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function encodeRfc2047Utf8(text: string): string {
+  const bytes = new TextEncoder().encode(text);
+  let quotedPrintable = "";
+  for (const byte of bytes) {
+    if (byte === 32) {
+      quotedPrintable += "_";
+    } else if ((byte >= 33 && byte <= 60) || (byte >= 62 && byte <= 126)) {
+      quotedPrintable += String.fromCharCode(byte);
+    } else {
+      quotedPrintable += `=${byte.toString(16).toUpperCase().padStart(2, "0")}`;
+    }
+  }
+  return `=?UTF-8?Q?${quotedPrintable}?=`;
+}
+
+function formatDisplayNameForHeader(displayName: string): string {
+  const sanitizedName = sanitizeHeaderDisplayText(displayName);
+  if (!sanitizedName) {
+    return "";
+  }
+
+  if (isRfc2047EncodedWord(sanitizedName)) {
+    return sanitizedName;
+  }
+
+  if (containsNonAscii(sanitizedName)) {
+    return encodeRfc2047Utf8(sanitizedName);
+  }
+
+  const escapedName = sanitizedName.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  return `"${escapedName}"`;
+}
+
+function formatFromHeaderValue(
+  displayName: string,
+  envelopeEmail: string,
+  sourceEmail?: string,
+): string {
+  const sanitizedEmail = sanitizeEmailAddress(envelopeEmail);
+  const formattedDisplayName = formatDisplayNameForHeader(displayName);
+  const compareEmail = sourceEmail ? sanitizeEmailAddress(sourceEmail) : sanitizedEmail;
+  const bareDisplayName = formattedDisplayName.replace(/^"|"$/g, "");
+
+  if (!formattedDisplayName || bareDisplayName === compareEmail.split("@")[0]) {
+    return sanitizedEmail;
+  }
+
+  return `${formattedDisplayName} <${sanitizedEmail}>`;
 }
 
 function formatMailboxHeaderValue(name: string, email: string): string {
   const sanitizedEmail = sanitizeEmailAddress(email);
-  const sanitizedName = sanitizeHeaderDisplayText(name);
+  const formattedDisplayName = formatDisplayNameForHeader(name);
 
-  if (!sanitizedName || sanitizedName === sanitizedEmail.split("@")[0]) {
+  if (
+    !formattedDisplayName ||
+    formattedDisplayName.replace(/^"|"$/g, "") === sanitizedEmail.split("@")[0]
+  ) {
     return sanitizedEmail;
   }
 
-  const escapedName = sanitizedName.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
-  return `"${escapedName}" <${sanitizedEmail}>`;
+  return `${formattedDisplayName} <${sanitizedEmail}>`;
+}
+
+function shouldPreserveReplyToHeader(originalFrom: string): boolean {
+  const trimmed = originalFrom.replace(/\s+/g, " ").trim();
+  return /<[^<>]+@[^<>]+>/.test(trimmed) && isRfc2047EncodedWord(trimmed);
 }
 
 function canNotifySender(senderEmail: string): boolean {
-  const normalizedSenderEmail = senderEmail.trim().toLowerCase();
+  const normalizedSenderEmail = sanitizeEmailAddress(senderEmail).toLowerCase();
   return (
     normalizedSenderEmail.length > 0 &&
     normalizedSenderEmail !== UNKNOWN_SENDER_PLACEHOLDER_EMAIL &&
@@ -310,9 +440,9 @@ async function notifySenderAboutOversizedEmail(params: {
 
   await ses.send(
     new SendEmailCommand({
-      FromEmailAddress: FORWARD_FROM_EMAIL,
+      FromEmailAddress: sanitizeEmailAddress(FORWARD_FROM_EMAIL),
       Destination: {
-        ToAddresses: [senderEmail],
+        ToAddresses: [sanitizeEmailAddress(senderEmail)],
       },
       Content: {
         Simple: {
@@ -369,16 +499,47 @@ function stripBlockedForwardHeaders(headers: string): string {
   return strippedHeaders.join("\r\n");
 }
 
+function replaceHeaderLineAndStripContinuations(
+  headers: string,
+  headerName: "From" | "To",
+  replacementValue: string,
+): string {
+  const headerLines = headers.split(/\r?\n/);
+  const rewrittenHeaders: string[] = [];
+  let skippingContinuation = false;
+  const headerPattern = new RegExp(`^${headerName}:`, "i");
+
+  for (const line of headerLines) {
+    if (/^[ \t]/.test(line)) {
+      if (!skippingContinuation) {
+        rewrittenHeaders.push(line);
+      }
+      continue;
+    }
+
+    if (headerPattern.test(line)) {
+      rewrittenHeaders.push(`${headerName}: ${replacementValue}`);
+      skippingContinuation = true;
+      continue;
+    }
+
+    skippingContinuation = false;
+    rewrittenHeaders.push(line);
+  }
+
+  return rewrittenHeaders.join("\r\n");
+}
+
 function buildForwardFromHeaderValue(originalFrom: string, newFrom: string): string {
   const sender = parseOriginalSender(originalFrom);
-  const fromDisplayText = `${sender.name} (${sender.email})`;
-  const escapedFromDisplayText = sanitizeHeaderDisplayText(fromDisplayText)
-    .replace(/\\/g, "\\\\")
-    .replace(/"/g, '\\"');
-  return `"${escapedFromDisplayText}" <${sanitizeEmailAddress(newFrom)}>`;
+  return formatFromHeaderValue(sender.name, newFrom, sender.email);
 }
 
 function buildReplyToHeaderValue(originalFrom: string): string {
+  if (shouldPreserveReplyToHeader(originalFrom)) {
+    return originalFrom.replace(/\s+/g, " ").trim();
+  }
+
   const sender = parseOriginalSender(originalFrom);
   return formatMailboxHeaderValue(sender.name, sender.email);
 }
@@ -392,11 +553,8 @@ function applyForwardingHeaderRewrites(
   const sanitizedTo = sanitizeEmailAddress(newTo);
   const replyTo = buildReplyToHeaderValue(originalFrom);
 
-  const rewritten = headers
-    // Replace From header
-    .replace(/^from:.*$/im, `From: ${rewrittenFrom}`)
-    // Replace To header
-    .replace(/^to:.*$/im, `To: ${sanitizedTo}`);
+  let rewritten = replaceHeaderLineAndStripContinuations(headers, "From", rewrittenFrom);
+  rewritten = replaceHeaderLineAndStripContinuations(rewritten, "To", sanitizedTo);
 
   return `${rewritten}\r\nReply-To: ${replyTo}`;
 }
@@ -440,12 +598,13 @@ function extractFromAddress(rawMime: string): string {
 async function sendForwardedEmail(input: SendForwardedEmailInput): Promise<ForwardSendResult> {
   const { rawMime, originalFrom, newFrom, target, s3Key, errorContext } = input;
   const sanitizedTarget = sanitizeEmailAddress(target);
+  const sanitizedFrom = sanitizeEmailAddress(newFrom);
 
   try {
-    const rewritten = rewriteMimeHeaders(rawMime, originalFrom, newFrom, sanitizedTarget);
+    const rewritten = rewriteMimeHeaders(rawMime, originalFrom, sanitizedFrom, sanitizedTarget);
     await ses.send(
       new SendEmailCommand({
-        FromEmailAddress: newFrom,
+        FromEmailAddress: sanitizedFrom,
         Destination: {
           ToAddresses: [sanitizedTarget],
         },
@@ -466,22 +625,44 @@ async function sendForwardedEmail(input: SendForwardedEmailInput): Promise<Forwa
     return { success: true };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
+    const rewrittenFrom = buildForwardFromHeaderValue(originalFrom, sanitizedFrom);
+    const replyTo = buildReplyToHeaderValue(originalFrom);
+    const sentryExtra = {
+      target: sanitizedTarget,
+      originalTarget: target,
+      s3Key,
+      originalFrom,
+      rewrittenFrom,
+      replyTo,
+      ...(errorContext.kind === "individual" ? { toAddress: errorContext.toAddress } : {}),
+    };
 
     if (errorContext.kind === "group") {
-      logger.error("Failed to forward to group member", { target, error: message });
-      Sentry.captureException(err, { extra: { target, s3Key } });
+      logger.error("Failed to forward to group member", {
+        target: sanitizedTarget,
+        originalTarget: target,
+        error: message,
+        originalFrom,
+        rewrittenFrom,
+        replyTo,
+      });
+      Sentry.captureException(err, { extra: sentryExtra });
     } else {
       logger.error("Failed to forward individual alias", {
         toAddress: errorContext.toAddress,
+        target: sanitizedTarget,
         error: message,
+        originalFrom,
+        rewrittenFrom,
+        replyTo,
       });
-      Sentry.captureException(err, { extra: { toAddress: errorContext.toAddress, s3Key } });
+      Sentry.captureException(err, { extra: sentryExtra });
     }
 
     return {
       success: false,
       error: message,
-      target,
+      target: sanitizedTarget,
     };
   }
 }
@@ -688,12 +869,24 @@ const lambdaHandler = async (event: unknown) => {
       continue;
     }
 
+    const sanitizedPrivateEmail = sanitizeRoutableEmail(member.privateEmail, {
+      memberId: member.id,
+      source: "individual",
+    });
+    if (!sanitizedPrivateEmail) {
+      logger.info("Member private email is not routable — skipping", {
+        toAddress,
+        memberId: member.id,
+      });
+      continue;
+    }
+
     logger.info("Forwarding individual alias", { toAddress, targetMember: member.id });
     const result = await sendForwardedEmail({
       rawMime,
       originalFrom,
       newFrom: FORWARD_FROM_EMAIL,
-      target: member.privateEmail,
+      target: sanitizedPrivateEmail,
       s3Key,
       errorContext: { kind: "individual", toAddress },
     });


### PR DESCRIPTION
Preserve RFC 2047 sender names, sanitize routable addresses, strip folded To continuations, and enrich Sentry context so production forwarding failures are easier to diagnose.

Fixes VOLLEYBALL-WEBSITE-68
Fixes VOLLEYBALL-WEBSITE-6C