### PR TITLE
Return empty SAMS matches instead of throwing on empty API pages.

### DIFF
--- a/app/src/server/functions/sams.server.ts
+++ b/app/src/server/functions/sams.server.ts
@@ -13,6 +13,7 @@ import {
   type LeagueMatchDto,
 } from "@codegen/sams/generated";
 import { InvokeCommand, LambdaClient } from "@aws-sdk/client-lambda";
+import * as Sentry from "@sentry/tanstackstart-react";
 import { createCacheKey, createExpiringCache, getOrSetExpiringCacheValue } from "@utils/cache";
 import dayjs from "dayjs";
 import { z } from "zod";
@@ -208,7 +209,22 @@ async function fetchAllSamsLeagueMatches({
 
       if (!pageData) {
         if (currentPage === 0) {
-          throw new Error(`SAMS API returned no data on page ${currentPage}`);
+          console.warn("SAMS API returned no data on first page", {
+            page: currentPage,
+            sportsclubUuid,
+            league,
+            season,
+            team,
+          });
+          Sentry.metrics.count("sams.league_matches.empty_response", 1, {
+            attributes: {
+              page: String(currentPage),
+              sportsclub_uuid: sportsclubUuid ?? "",
+              league: league ?? "",
+              season: season ?? "",
+              team: team ?? "",
+            },
+          });
         }
         break;
       }


### PR DESCRIPTION
Log the condition and emit a Sentry metric so empty first-page responses no longer fail match queries in the webapp.