### PR TITLE
Ignore JSON key-order noise in SAMS swagger drift checks

### DIFF
--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "hooks": {
+    "beforeShellExecution": [
+      {
+        "command": ".cursor/hooks/vp-check-before-commit.sh",
+        "matcher": "git\\s+commit",
+        "failClosed": true,
+        "timeout": 300
+      }
+    ]
+  }
+}

--- a/.cursor/hooks/vp-check-before-commit.sh
+++ b/.cursor/hooks/vp-check-before-commit.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Cursor project hooks run from the repository root.
+status_before=$(git status --porcelain 2>/dev/null || true)
+
+if ! vp check --fix; then
+  printf '%s\n' \
+    '{"permission":"deny","user_message":"Commit blocked: vp check --fix failed. Fix lint, format, or type errors before committing.","agent_message":"vp check --fix failed. Resolve the reported issues, then retry the commit."}'
+  exit 2
+fi
+
+status_after=$(git status --porcelain 2>/dev/null || true)
+if [[ "$status_before" != "$status_after" ]]; then
+  printf '%s\n' \
+    '{"permission":"deny","user_message":"Commit blocked: vp check --fix modified files. Re-stage the changes and commit again.","agent_message":"vp check --fix auto-fixed files. Stage the updated files before committing again."}'
+  exit 2
+fi
+
+printf '%s\n' '{"permission":"allow"}'

--- a/.cursor/settings.json
+++ b/.cursor/settings.json
@@ -1,0 +1,7 @@
+{
+  "plugins": {
+    "aws-core": {
+      "enabled": true
+    }
+  }
+}

--- a/.cursor/worktrees.json
+++ b/.cursor/worktrees.json
@@ -1,0 +1,3 @@
+{
+  "setup-worktree": ["git fetch origin main", "git merge origin/main --no-edit", "vp install"]
+}

--- a/.github/workflows/sams-health-check.yml
+++ b/.github/workflows/sams-health-check.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       has_drift: ${{ steps.diff.outputs.has_drift }}
+      drift_summary_markdown: ${{ steps.diff.outputs.drift_summary_markdown }}
     steps:
       - uses: actions/checkout@v6
 
@@ -25,33 +26,49 @@ jobs:
           node-version: "25"
           cache: true
 
+      - uses: oven-sh/setup-bun@v2
+
       - name: Install dependencies
         run: vp install
+
+      - name: Snapshot committed source.json
+        run: git show HEAD:codegen/sams/generated/source.json > /tmp/committed-source.json
 
       - name: Regenerate from live spec
         run: vp run sams:codegen
 
-      - name: Detect drift in source.json
+      - name: Detect semantic drift in source.json
         id: diff
         run: |
-          if git diff --quiet codegen/sams/generated/source.json; then
-            echo "has_drift=false" >> "$GITHUB_OUTPUT"
-            echo "✅ source.json unchanged — no upstream spec changes." >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "has_drift=true" >> "$GITHUB_OUTPUT"
-            {
-              echo "## ⚠️ Swagger drift detected"
-              echo ""
-              echo '```'
-              git diff --stat codegen/sams/generated/source.json
-              echo '```'
-              echo ""
-              echo "### Changed paths (sample)"
-              echo '```'
-              git diff codegen/sams/generated/source.json | grep '^[+-]' | grep -v '^[+-][+-][+-]' | head -40
-              echo '```'
-            } >> "$GITHUB_STEP_SUMMARY"
-          fi
+          bun scripts/check-sams-swagger-drift.ts \
+            /tmp/committed-source.json \
+            codegen/sams/generated/source.json \
+            > /tmp/swagger-drift-result.json
+
+          node -e "
+            const fs = require('fs');
+            const result = JSON.parse(fs.readFileSync('/tmp/swagger-drift-result.json', 'utf8'));
+            const summary = result.summaryMarkdown ?? '';
+            fs.appendFileSync(process.env.GITHUB_OUTPUT, 'has_drift=' + (result.hasDrift ? 'true' : 'false') + '\n');
+            fs.appendFileSync(process.env.GITHUB_OUTPUT, 'drift_summary_markdown<<EOF\n' + summary + '\nEOF\n');
+
+            if (!result.hasDrift) {
+              fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, '✅ source.json semantically unchanged — no upstream spec changes.\\n');
+              return;
+            }
+
+            const lines = [
+              '## ⚠️ Swagger drift detected',
+              '',
+              result.changeCount + ' semantic change(s) in codegen/sams/generated/source.json',
+              '',
+              '### What changed',
+              '',
+              summary,
+              '',
+            ];
+            fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, lines.join('\\n') + '\\n');
+          "
 
   # ── Job 2: Verify known upstream API bugs are still present ───────────────────
   bug-check:
@@ -207,6 +224,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HAS_DRIFT: ${{ needs.swagger-drift.outputs.has_drift }}
+          DRIFT_SUMMARY_MARKDOWN: ${{ needs.swagger-drift.outputs.drift_summary_markdown }}
           HAS_FIXED: ${{ needs.bug-check.outputs.has_fixed }}
           FIXED_BUG_IDS: ${{ needs.bug-check.outputs.fixed_bug_ids }}
           CHECK_FAILED_IDS: ${{ needs.bug-check.outputs.check_failed_ids }}

--- a/.github/workflows/sams-health-check.yml
+++ b/.github/workflows/sams-health-check.yml
@@ -42,33 +42,7 @@ jobs:
         run: |
           bun scripts/check-sams-swagger-drift.ts \
             /tmp/committed-source.json \
-            codegen/sams/generated/source.json \
-            > /tmp/swagger-drift-result.json
-
-          node -e "
-            const fs = require('fs');
-            const result = JSON.parse(fs.readFileSync('/tmp/swagger-drift-result.json', 'utf8'));
-            const summary = result.summaryMarkdown ?? '';
-            fs.appendFileSync(process.env.GITHUB_OUTPUT, 'has_drift=' + (result.hasDrift ? 'true' : 'false') + '\n');
-            fs.appendFileSync(process.env.GITHUB_OUTPUT, 'drift_summary_markdown<<EOF\n' + summary + '\nEOF\n');
-
-            if (!result.hasDrift) {
-              fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, '✅ source.json semantically unchanged — no upstream spec changes.\\n');
-              return;
-            }
-
-            const lines = [
-              '## ⚠️ Swagger drift detected',
-              '',
-              result.changeCount + ' semantic change(s) in codegen/sams/generated/source.json',
-              '',
-              '### What changed',
-              '',
-              summary,
-              '',
-            ];
-            fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, lines.join('\\n') + '\\n');
-          "
+            codegen/sams/generated/source.json
 
   # ── Job 2: Verify known upstream API bugs are still present ───────────────────
   bug-check:

--- a/scripts/check-sams-swagger-drift.ts
+++ b/scripts/check-sams-swagger-drift.ts
@@ -6,14 +6,20 @@
  *   bun scripts/check-sams-swagger-drift.ts <committed.json> <regenerated.json>
  *
  * Prints JSON: { hasDrift, changeCount, summaryMarkdown }
+ * When GITHUB_OUTPUT / GITHUB_STEP_SUMMARY are set (Actions), also appends job outputs and the step summary.
  * Exits 0 when the check completes (drift or not).
  * Exits 1 on usage errors or invalid JSON.
  *
  * Used by .github/workflows/sams-health-check.yml
  */
 
-import { readFileSync } from "node:fs";
-import { compareSwaggerSnapshots, formatDriftSummaryMarkdown } from "./sams-swagger-drift";
+import { appendFileSync, readFileSync } from "node:fs";
+import {
+  compareSwaggerSnapshots,
+  formatDriftSummaryMarkdown,
+  formatGithubOutputFile,
+  formatGithubStepSummary,
+} from "./sams-swagger-drift";
 
 const committedPath = process.argv[2];
 const regeneratedPath = process.argv[3];
@@ -43,11 +49,35 @@ try {
   process.exit(1);
 }
 
+const summaryMarkdown = formatDriftSummaryMarkdown(result.changes);
 const output = {
   hasDrift: result.hasDrift,
   changeCount: result.changes.length,
-  summaryMarkdown: formatDriftSummaryMarkdown(result.changes),
+  summaryMarkdown,
 };
+
+const githubOutputPath = process.env.GITHUB_OUTPUT;
+if (githubOutputPath) {
+  appendFileSync(
+    githubOutputPath,
+    formatGithubOutputFile({
+      hasDrift: result.hasDrift,
+      summaryMarkdown,
+    }),
+  );
+}
+
+const githubStepSummaryPath = process.env.GITHUB_STEP_SUMMARY;
+if (githubStepSummaryPath) {
+  appendFileSync(
+    githubStepSummaryPath,
+    formatGithubStepSummary({
+      hasDrift: result.hasDrift,
+      changeCount: result.changes.length,
+      summaryMarkdown,
+    }),
+  );
+}
 
 console.log(JSON.stringify(output));
 process.exit(0);

--- a/scripts/check-sams-swagger-drift.ts
+++ b/scripts/check-sams-swagger-drift.ts
@@ -1,0 +1,53 @@
+#!/usr/bin/env bun
+/**
+ * Compares committed vs regenerated SAMS swagger source.json with key-order-insensitive equality.
+ *
+ * Usage:
+ *   bun scripts/check-sams-swagger-drift.ts <committed.json> <regenerated.json>
+ *
+ * Prints JSON: { hasDrift, changeCount, summaryMarkdown }
+ * Exits 0 when the check completes (drift or not).
+ * Exits 1 on usage errors or invalid JSON.
+ *
+ * Used by .github/workflows/sams-health-check.yml
+ */
+
+import { readFileSync } from "node:fs";
+import { compareSwaggerSnapshots, formatDriftSummaryMarkdown } from "./sams-swagger-drift";
+
+const committedPath = process.argv[2];
+const regeneratedPath = process.argv[3];
+
+if (!committedPath || !regeneratedPath) {
+  console.error(
+    "Usage: bun scripts/check-sams-swagger-drift.ts <committed.json> <regenerated.json>",
+  );
+  process.exit(1);
+}
+
+let committedJson: string;
+let regeneratedJson: string;
+try {
+  committedJson = readFileSync(committedPath, "utf8");
+  regeneratedJson = readFileSync(regeneratedPath, "utf8");
+} catch (error) {
+  console.error(`Failed to read swagger snapshot files: ${String(error)}`);
+  process.exit(1);
+}
+
+let result: ReturnType<typeof compareSwaggerSnapshots>;
+try {
+  result = compareSwaggerSnapshots(committedJson, regeneratedJson);
+} catch (error) {
+  console.error(`Failed to parse swagger JSON: ${String(error)}`);
+  process.exit(1);
+}
+
+const output = {
+  hasDrift: result.hasDrift,
+  changeCount: result.changes.length,
+  summaryMarkdown: formatDriftSummaryMarkdown(result.changes),
+};
+
+console.log(JSON.stringify(output));
+process.exit(0);

--- a/scripts/sams-notify.ts
+++ b/scripts/sams-notify.ts
@@ -10,7 +10,7 @@
  * Bug descriptions must stay in sync with scripts/check-sams-bugs.ts.
  */
 
-export {};
+import { buildSwaggerDriftSection } from "./sams-swagger-drift";
 
 const token = process.env.GITHUB_TOKEN;
 const repository = process.env.GITHUB_REPOSITORY; // "owner/repo"
@@ -34,6 +34,7 @@ const failureStep = process.env.FAILURE_STEP ?? "";
 const swaggerJobFailed = process.env.SWAGGER_DRIFT_RESULT === "failure";
 const bugCheckJobFailed = process.env.BUG_CHECK_RESULT === "failure";
 const regenJobFailed = process.env.REGENERATE_RESULT === "failure";
+const driftSummaryMarkdown = process.env.DRIFT_SUMMARY_MARKDOWN ?? "";
 
 const bugDescriptions: Record<number, string> = {
   2: "`logoImageForScreenOutputLink` always `null` on `GET /teams/{uuid}`",
@@ -65,13 +66,12 @@ const titleParts: string[] = [];
 if (hasDrift) {
   labels.push("drift-detection");
   titleParts.push("⚠️ swagger drift");
-  sections.push(`## ⚠️ Swagger Drift Detected
-
-The upstream spec at \`https://www.volleyball-baden.de/api/v2/swagger.json\` has changed since the last committed raw snapshot in \`codegen/sams/generated/input.json\`.
-
-Run \`bun run sams:codegen\` locally, review \`codegen/sams/generated/input.json\` for the upstream change and \`codegen/sams/generated/source.json\` plus the generated client files for downstream impact, then commit the updated files once verified.
-
-[Full diff in workflow run](${runUrl})`);
+  sections.push(
+    buildSwaggerDriftSection({
+      runUrl,
+      summaryMarkdown: driftSummaryMarkdown,
+    }),
+  );
 }
 
 if (hasFixed) {

--- a/scripts/sams-swagger-drift.test.ts
+++ b/scripts/sams-swagger-drift.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  buildSwaggerDriftSection,
+  compareSwaggerSnapshots,
+  formatDriftSummaryMarkdown,
+  jsonEqualIgnoringKeyOrder,
+} from "./sams-swagger-drift";
+
+describe("jsonEqualIgnoringKeyOrder", () => {
+  it("treats objects with the same keys and values as equal regardless of key order", () => {
+    expect(
+      jsonEqualIgnoringKeyOrder(
+        { delayPossible: true, indefinitelyRescheduled: false },
+        { indefinitelyRescheduled: false, delayPossible: true },
+      ),
+    ).toBe(true);
+  });
+
+  it("reports inequality when a value differs", () => {
+    expect(
+      jsonEqualIgnoringKeyOrder(
+        { delayPossible: true, indefinitelyRescheduled: false },
+        { delayPossible: false, indefinitelyRescheduled: false },
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("compareSwaggerSnapshots", () => {
+  it("reports no drift when only object key order differs", () => {
+    const committed = JSON.stringify({
+      components: {
+        schemas: {
+          MatchStatus: {
+            properties: {
+              indefinitelyRescheduled: { type: "boolean" },
+              delayPossible: { type: "boolean" },
+            },
+          },
+        },
+      },
+    });
+    const regenerated = JSON.stringify({
+      components: {
+        schemas: {
+          MatchStatus: {
+            properties: {
+              delayPossible: { type: "boolean" },
+              indefinitelyRescheduled: { type: "boolean" },
+            },
+          },
+        },
+      },
+    });
+
+    const result = compareSwaggerSnapshots(committed, regenerated);
+
+    expect(result.hasDrift).toBe(false);
+    expect(result.changes).toEqual([]);
+  });
+
+  it("reports drift with concrete paths when a property value changes", () => {
+    const committed = JSON.stringify({
+      components: {
+        schemas: {
+          MatchStatus: {
+            properties: {
+              delayPossible: { type: "boolean" },
+            },
+          },
+        },
+      },
+    });
+    const regenerated = JSON.stringify({
+      components: {
+        schemas: {
+          MatchStatus: {
+            properties: {
+              delayPossible: { type: "string" },
+            },
+          },
+        },
+      },
+    });
+
+    const result = compareSwaggerSnapshots(committed, regenerated);
+
+    expect(result.hasDrift).toBe(true);
+    expect(result.changes).toEqual([
+      {
+        kind: "changed",
+        path: "components.schemas.MatchStatus.properties.delayPossible.type",
+        before: "boolean",
+        after: "string",
+      },
+    ]);
+  });
+
+  it("reports added and removed properties as drift", () => {
+    const committed = JSON.stringify({
+      properties: {
+        delayPossible: { type: "boolean" },
+      },
+    });
+    const regenerated = JSON.stringify({
+      properties: {
+        indefinitelyRescheduled: { type: "boolean" },
+      },
+    });
+
+    const result = compareSwaggerSnapshots(committed, regenerated);
+
+    expect(result.hasDrift).toBe(true);
+    expect(result.changes).toEqual([
+      {
+        kind: "removed",
+        path: "properties.delayPossible",
+        before: { type: "boolean" },
+      },
+      {
+        kind: "added",
+        path: "properties.indefinitelyRescheduled",
+        after: { type: "boolean" },
+      },
+    ]);
+  });
+});
+
+describe("formatDriftSummaryMarkdown", () => {
+  it("lists each changed path for the notify issue body", () => {
+    const markdown = formatDriftSummaryMarkdown([
+      {
+        kind: "changed",
+        path: "components.schemas.MatchStatus.properties.delayPossible.type",
+        before: "boolean",
+        after: "string",
+      },
+      {
+        kind: "added",
+        path: "components.schemas.NewDto",
+        after: { type: "object" },
+      },
+    ]);
+
+    expect(markdown).toContain("delayPossible.type");
+    expect(markdown).toContain("`boolean` → `string`");
+    expect(markdown).toContain("NewDto");
+    expect(markdown).toContain("added");
+  });
+});
+
+describe("buildSwaggerDriftSection", () => {
+  it("points reviewers at source.json and embeds the semantic change summary", () => {
+    const section = buildSwaggerDriftSection({
+      runUrl: "https://github.com/example/run/1",
+      summaryMarkdown: "- **changed** `foo.type`: `boolean` → `string`",
+    });
+
+    expect(section).toContain("codegen/sams/generated/source.json");
+    expect(section).not.toContain("input.json");
+    expect(section).toContain("### What changed");
+    expect(section).toContain("`foo.type`");
+    expect(section).toContain("https://github.com/example/run/1");
+    expect(section).toContain("View workflow run");
+  });
+});
+
+describe("check-sams-swagger-drift CLI", () => {
+  it("reports no drift for key-order-only differences and drift for real changes", async () => {
+    const { mkdtempSync, writeFileSync, rmSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const { execFileSync } = await import("node:child_process");
+
+    const dir = mkdtempSync(join(tmpdir(), "sams-swagger-drift-"));
+    try {
+      const committed = join(dir, "committed.json");
+      const regeneratedSame = join(dir, "regenerated-same.json");
+      const regeneratedChanged = join(dir, "regenerated-changed.json");
+
+      writeFileSync(
+        committed,
+        JSON.stringify({
+          properties: {
+            indefinitelyRescheduled: { type: "boolean" },
+            delayPossible: { type: "boolean" },
+          },
+        }),
+      );
+      writeFileSync(
+        regeneratedSame,
+        JSON.stringify({
+          properties: {
+            delayPossible: { type: "boolean" },
+            indefinitelyRescheduled: { type: "boolean" },
+          },
+        }),
+      );
+      writeFileSync(
+        regeneratedChanged,
+        JSON.stringify({
+          properties: {
+            delayPossible: { type: "string" },
+            indefinitelyRescheduled: { type: "boolean" },
+          },
+        }),
+      );
+
+      const sameOutput = execFileSync(
+        "bun",
+        ["scripts/check-sams-swagger-drift.ts", committed, regeneratedSame],
+        { encoding: "utf8", cwd: process.cwd() },
+      );
+      const sameResult = JSON.parse(sameOutput) as { hasDrift: boolean; changeCount: number };
+      expect(sameResult.hasDrift).toBe(false);
+      expect(sameResult.changeCount).toBe(0);
+
+      const changedOutput = execFileSync(
+        "bun",
+        ["scripts/check-sams-swagger-drift.ts", committed, regeneratedChanged],
+        { encoding: "utf8", cwd: process.cwd() },
+      );
+      const changedResult = JSON.parse(changedOutput) as {
+        hasDrift: boolean;
+        changeCount: number;
+        summaryMarkdown: string;
+      };
+      expect(changedResult.hasDrift).toBe(true);
+      expect(changedResult.changeCount).toBeGreaterThan(0);
+      expect(changedResult.summaryMarkdown).toContain("delayPossible");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/sams-swagger-drift.test.ts
+++ b/scripts/sams-swagger-drift.test.ts
@@ -3,6 +3,8 @@ import {
   buildSwaggerDriftSection,
   compareSwaggerSnapshots,
   formatDriftSummaryMarkdown,
+  formatGithubOutputFile,
+  formatGithubStepSummary,
   jsonEqualIgnoringKeyOrder,
 } from "./sams-swagger-drift";
 
@@ -165,9 +167,37 @@ describe("buildSwaggerDriftSection", () => {
   });
 });
 
+describe("GitHub Actions output helpers", () => {
+  it("formats step summary and job outputs for Actions to pick up", () => {
+    const summary = formatGithubStepSummary({
+      hasDrift: true,
+      changeCount: 1,
+      summaryMarkdown: "- **changed** `foo.type`: `boolean` → `string`",
+    });
+    expect(summary).toContain("Swagger drift detected");
+    expect(summary).toContain("### What changed");
+    expect(summary).toContain("foo.type");
+
+    const noDrift = formatGithubStepSummary({
+      hasDrift: false,
+      changeCount: 0,
+      summaryMarkdown: "",
+    });
+    expect(noDrift).toContain("semantically unchanged");
+
+    const outputs = formatGithubOutputFile({
+      hasDrift: true,
+      summaryMarkdown: "- **changed** `foo`",
+    });
+    expect(outputs).toContain("has_drift=true");
+    expect(outputs).toContain("drift_summary_markdown<<SWAGGER_DRIFT_EOF");
+    expect(outputs).toContain("- **changed** `foo`");
+  });
+});
+
 describe("check-sams-swagger-drift CLI", () => {
   it("reports no drift for key-order-only differences and drift for real changes", async () => {
-    const { mkdtempSync, writeFileSync, rmSync } = await import("node:fs");
+    const { mkdtempSync, writeFileSync, readFileSync, rmSync } = await import("node:fs");
     const { tmpdir } = await import("node:os");
     const { join } = await import("node:path");
     const { execFileSync } = await import("node:child_process");
@@ -177,6 +207,8 @@ describe("check-sams-swagger-drift CLI", () => {
       const committed = join(dir, "committed.json");
       const regeneratedSame = join(dir, "regenerated-same.json");
       const regeneratedChanged = join(dir, "regenerated-changed.json");
+      const githubOutput = join(dir, "github-output");
+      const githubStepSummary = join(dir, "github-step-summary");
 
       writeFileSync(
         committed,
@@ -215,10 +247,20 @@ describe("check-sams-swagger-drift CLI", () => {
       expect(sameResult.hasDrift).toBe(false);
       expect(sameResult.changeCount).toBe(0);
 
+      writeFileSync(githubOutput, "");
+      writeFileSync(githubStepSummary, "");
       const changedOutput = execFileSync(
         "bun",
         ["scripts/check-sams-swagger-drift.ts", committed, regeneratedChanged],
-        { encoding: "utf8", cwd: process.cwd() },
+        {
+          encoding: "utf8",
+          cwd: process.cwd(),
+          env: {
+            ...process.env,
+            GITHUB_OUTPUT: githubOutput,
+            GITHUB_STEP_SUMMARY: githubStepSummary,
+          },
+        },
       );
       const changedResult = JSON.parse(changedOutput) as {
         hasDrift: boolean;
@@ -228,6 +270,9 @@ describe("check-sams-swagger-drift CLI", () => {
       expect(changedResult.hasDrift).toBe(true);
       expect(changedResult.changeCount).toBeGreaterThan(0);
       expect(changedResult.summaryMarkdown).toContain("delayPossible");
+
+      expect(readFileSync(githubOutput, "utf8")).toContain("has_drift=true");
+      expect(readFileSync(githubStepSummary, "utf8")).toContain("What changed");
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/scripts/sams-swagger-drift.ts
+++ b/scripts/sams-swagger-drift.ts
@@ -1,0 +1,221 @@
+/**
+ * Canonical JSON comparison and semantic drift summaries for SAMS swagger checks.
+ * Used by scripts/check-sams-swagger-drift.ts and the sams-health-check workflow.
+ */
+
+export type JsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+export type JsonDriftChange =
+  | { kind: "added"; path: string; after: JsonValue }
+  | { kind: "removed"; path: string; before: JsonValue }
+  | { kind: "changed"; path: string; before: JsonValue; after: JsonValue };
+
+export type SwaggerSnapshotCompareResult = {
+  hasDrift: boolean;
+  changes: JsonDriftChange[];
+};
+
+function isPlainObject(value: unknown): value is Record<string, JsonValue> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asJsonValue(value: unknown): JsonValue {
+  if (
+    value === null ||
+    typeof value === "boolean" ||
+    typeof value === "number" ||
+    typeof value === "string"
+  ) {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    const items: JsonValue[] = [];
+    for (const item of value) {
+      items.push(asJsonValue(item));
+    }
+    return items;
+  }
+  if (isPlainObject(value)) {
+    const result: { [key: string]: JsonValue } = {};
+    for (const [key, child] of Object.entries(value)) {
+      result[key] = asJsonValue(child);
+    }
+    return result;
+  }
+  throw new Error(`Unsupported JSON value type: ${typeof value}`);
+}
+
+/** Deep equality that ignores object key insertion order. */
+export function jsonEqualIgnoringKeyOrder(left: unknown, right: unknown): boolean {
+  if (Object.is(left, right)) {
+    return true;
+  }
+
+  if (Array.isArray(left) && Array.isArray(right)) {
+    if (left.length !== right.length) {
+      return false;
+    }
+    for (let i = 0; i < left.length; i++) {
+      if (!jsonEqualIgnoringKeyOrder(left[i], right[i])) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  if (isPlainObject(left) && isPlainObject(right)) {
+    const leftKeys = Object.keys(left);
+    const rightKeys = Object.keys(right);
+    if (leftKeys.length !== rightKeys.length) {
+      return false;
+    }
+    const rightKeySet = new Set(rightKeys);
+    for (const key of leftKeys) {
+      if (!rightKeySet.has(key)) {
+        return false;
+      }
+      if (!jsonEqualIgnoringKeyOrder(left[key], right[key])) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  return false;
+}
+
+function collectJsonDrift(
+  left: JsonValue,
+  right: JsonValue,
+  path: string,
+  out: JsonDriftChange[],
+): void {
+  if (jsonEqualIgnoringKeyOrder(left, right)) {
+    return;
+  }
+
+  if (Array.isArray(left) && Array.isArray(right)) {
+    const max = Math.max(left.length, right.length);
+    for (let i = 0; i < max; i++) {
+      const childPath = path ? `${path}[${i}]` : `[${i}]`;
+      if (i >= left.length) {
+        out.push({ kind: "added", path: childPath, after: right[i]! });
+        continue;
+      }
+      if (i >= right.length) {
+        out.push({ kind: "removed", path: childPath, before: left[i]! });
+        continue;
+      }
+      collectJsonDrift(left[i]!, right[i]!, childPath, out);
+    }
+    return;
+  }
+
+  if (isPlainObject(left) && isPlainObject(right)) {
+    const keys = new Set([...Object.keys(left), ...Object.keys(right)]);
+    for (const key of [...keys].sort()) {
+      const childPath = path ? `${path}.${key}` : key;
+      const hasLeft = Object.hasOwn(left, key);
+      const hasRight = Object.hasOwn(right, key);
+      if (!hasLeft) {
+        out.push({ kind: "added", path: childPath, after: right[key]! });
+        continue;
+      }
+      if (!hasRight) {
+        out.push({ kind: "removed", path: childPath, before: left[key]! });
+        continue;
+      }
+      collectJsonDrift(left[key]!, right[key]!, childPath, out);
+    }
+    return;
+  }
+
+  out.push({
+    kind: "changed",
+    path: path || "(root)",
+    before: left,
+    after: right,
+  });
+}
+
+/** Compare two OpenAPI JSON document strings; key order alone does not count as drift. */
+export function compareSwaggerSnapshots(
+  committedJson: string,
+  regeneratedJson: string,
+): SwaggerSnapshotCompareResult {
+  const committed = asJsonValue(JSON.parse(committedJson));
+  const regenerated = asJsonValue(JSON.parse(regeneratedJson));
+  const changes: JsonDriftChange[] = [];
+  collectJsonDrift(committed, regenerated, "", changes);
+  return {
+    hasDrift: changes.length > 0,
+    changes,
+  };
+}
+
+function formatJsonSnippet(value: JsonValue): string {
+  if (typeof value === "string") {
+    return `\`${value}\``;
+  }
+  if (typeof value === "number" || typeof value === "boolean" || value === null) {
+    return `\`${String(value)}\``;
+  }
+  const serialized = JSON.stringify(value);
+  if (serialized.length <= 80) {
+    return `\`${serialized}\``;
+  }
+  return `\`${serialized.slice(0, 77)}...\``;
+}
+
+/** Markdown list of semantic changes for CI summaries and GitHub issue bodies. */
+export function formatDriftSummaryMarkdown(changes: JsonDriftChange[], maxItems = 40): string {
+  if (changes.length === 0) {
+    return "_No semantic changes._";
+  }
+
+  const shown = changes.slice(0, maxItems);
+  const lines = shown.map((change) => {
+    switch (change.kind) {
+      case "added":
+        return `- **added** \`${change.path}\`: ${formatJsonSnippet(change.after)}`;
+      case "removed":
+        return `- **removed** \`${change.path}\`: ${formatJsonSnippet(change.before)}`;
+      case "changed":
+        return `- **changed** \`${change.path}\`: ${formatJsonSnippet(change.before)} → ${formatJsonSnippet(change.after)}`;
+    }
+  });
+
+  if (changes.length > maxItems) {
+    lines.push(`- _…and ${changes.length - maxItems} more_`);
+  }
+
+  return lines.join("\n");
+}
+
+const SOURCE_JSON_PATH = "codegen/sams/generated/source.json";
+
+/** GitHub issue section for swagger drift notifications. */
+export function buildSwaggerDriftSection(options: {
+  runUrl: string;
+  summaryMarkdown?: string;
+}): string {
+  const { runUrl, summaryMarkdown } = options;
+  const changeBlock =
+    summaryMarkdown && summaryMarkdown.trim().length > 0
+      ? `\n### What changed\n\n${summaryMarkdown}\n`
+      : "";
+
+  return `## ⚠️ Swagger Drift Detected
+
+The upstream spec at \`https://www.volleyball-baden.de/api/v2/swagger.json\` has changed since the last committed snapshot in \`${SOURCE_JSON_PATH}\`.
+
+Run \`bun run sams:codegen\` locally, review \`${SOURCE_JSON_PATH}\` plus the generated client files for downstream impact, then commit the updated files once verified.
+${changeBlock}
+[View workflow run](${runUrl})`;
+}

--- a/scripts/sams-swagger-drift.ts
+++ b/scripts/sams-swagger-drift.ts
@@ -200,6 +200,43 @@ export function formatDriftSummaryMarkdown(changes: JsonDriftChange[], maxItems 
 
 const SOURCE_JSON_PATH = "codegen/sams/generated/source.json";
 
+/** Job summary markdown written to $GITHUB_STEP_SUMMARY in CI. */
+export function formatGithubStepSummary(options: {
+  hasDrift: boolean;
+  changeCount: number;
+  summaryMarkdown: string;
+}): string {
+  if (!options.hasDrift) {
+    return "✅ source.json semantically unchanged — no upstream spec changes.\n";
+  }
+
+  return [
+    "## ⚠️ Swagger drift detected",
+    "",
+    `${options.changeCount} semantic change(s) in ${SOURCE_JSON_PATH}`,
+    "",
+    "### What changed",
+    "",
+    options.summaryMarkdown,
+    "",
+  ].join("\n");
+}
+
+/** Step outputs written to $GITHUB_OUTPUT in CI (multiline-safe). */
+export function formatGithubOutputFile(options: {
+  hasDrift: boolean;
+  summaryMarkdown: string;
+}): string {
+  const delimiter = "SWAGGER_DRIFT_EOF";
+  return [
+    `has_drift=${options.hasDrift ? "true" : "false"}`,
+    `drift_summary_markdown<<${delimiter}`,
+    options.summaryMarkdown,
+    delimiter,
+    "",
+  ].join("\n");
+}
+
 /** GitHub issue section for swagger drift notifications. */
 export function buildSwaggerDriftSection(options: {
   runUrl: string;


### PR DESCRIPTION
## Summary
- Compare regenerated `source.json` with key-order-insensitive equality so property reordering no longer opens false-positive drift issues
- Emit a path-level semantic change summary into the job summary, job outputs, and notify issue body
- Point drift notifications at `codegen/sams/generated/source.json` (not the non-existent `input.json`)
- Add Cursor worktree setup and pre-commit `vp check` hook

Closes #367

## Test plan
- [ ] `vp test scripts/sams-swagger-drift.test.ts` passes
- [ ] Manually or via workflow: key-order-only regenerate does **not** set `has_drift=true`
- [ ] Real schema change still sets `has_drift=true` and lists changed paths in the step summary / notify issue
- [ ] Notify copy mentions `source.json` only