### PR TITLE
Fix SAMS match loading for null team MVP fields

### DIFF
--- a/codegen/sams/generate-client.ts
+++ b/codegen/sams/generate-client.ts
@@ -37,8 +37,9 @@ createClient({
     patch: {
       schemas: {
         // _embedded (team1/team2) is not in the upstream spec — injected here based on actual API responses.
-        // results: null when no match has been played; referees: null when none assigned.
-        //   NOTE: hey-api no longer respects nullable:true on $ref fields — must use explicit anyOf with null instead.
+        // results: null when no match has been played; referees: null when none assigned;
+        // team1Mvp/team2Mvp: null when no MVP is assigned (typical for unplayed matches).
+        //   NOTE: hey-api no longer respects nullable:true on $ref fields — must use explicit allOf+nullable instead.
         // date.format corrected to "date" (upstream uses "date-time" which generates wrong Zod type).
         CompetitionMatchDto: (schema) => {
           if (schema.properties) {
@@ -74,9 +75,12 @@ createClient({
                   case "results":
                   case "referees":
                   case "location":
+                  case "team1Mvp":
+                  case "team2Mvp":
                     // hey-api silently drops nullable:true when paired with $ref — wrap in allOf
                     // so nullable:true is on a schema object (not a $ref), which the generator
                     // correctly converts to z.union([zType, z.null()]).
+                    // team1Mvp/team2Mvp are null when no MVP is assigned (common for unplayed matches).
                     schema.properties[key] = { allOf: [property], nullable: true };
                     break;
                   default:
@@ -124,9 +128,12 @@ createClient({
                   case "results":
                   case "referees":
                   case "location":
+                  case "team1Mvp":
+                  case "team2Mvp":
                     // hey-api silently drops nullable:true when paired with $ref — wrap in allOf
                     // so nullable:true is on a schema object (not a $ref), which the generator
                     // correctly converts to z.union([zType, z.null()]).
+                    // team1Mvp/team2Mvp are null when no MVP is assigned (common for unplayed matches).
                     schema.properties[key] = { allOf: [property], nullable: true };
                     break;
                   default:

--- a/codegen/sams/generated/source.json
+++ b/codegen/sams/generated/source.json
@@ -5863,11 +5863,19 @@
             "nullable": true
           },
           "team1Mvp": {
-            "$ref": "#/components/schemas/MostValuablePlayerDto",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MostValuablePlayerDto"
+              }
+            ],
             "nullable": true
           },
           "team2Mvp": {
-            "$ref": "#/components/schemas/MostValuablePlayerDto",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MostValuablePlayerDto"
+              }
+            ],
             "nullable": true
           },
           "matchGroupUuid": {
@@ -5878,11 +5886,11 @@
             "type": "string",
             "nullable": true
           },
-          "indefinitelyRescheduled": {
+          "delayPossible": {
             "type": "boolean",
             "nullable": true
           },
-          "delayPossible": {
+          "indefinitelyRescheduled": {
             "type": "boolean",
             "nullable": true
           }
@@ -6281,11 +6289,19 @@
             "nullable": true
           },
           "team1Mvp": {
-            "$ref": "#/components/schemas/MostValuablePlayerDto",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MostValuablePlayerDto"
+              }
+            ],
             "nullable": true
           },
           "team2Mvp": {
-            "$ref": "#/components/schemas/MostValuablePlayerDto",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MostValuablePlayerDto"
+              }
+            ],
             "nullable": true
           },
           "matchDayUuid": {
@@ -6296,11 +6312,11 @@
             "type": "string",
             "nullable": true
           },
-          "indefinitelyRescheduled": {
+          "delayPossible": {
             "type": "boolean",
             "nullable": true
           },
-          "delayPossible": {
+          "indefinitelyRescheduled": {
             "type": "boolean",
             "nullable": true
           }

--- a/codegen/sams/generated/types.gen.ts
+++ b/codegen/sams/generated/types.gen.ts
@@ -597,12 +597,12 @@ export type CompetitionMatchDto = {
   team1Description?: string | null;
   team2Description?: string | null;
   results?: VolleyballMatchResultsDto | null;
-  team1Mvp?: MostValuablePlayerDto;
-  team2Mvp?: MostValuablePlayerDto;
+  team1Mvp?: MostValuablePlayerDto | null;
+  team2Mvp?: MostValuablePlayerDto | null;
   matchGroupUuid?: string | null;
   competitionUuid?: string | null;
-  indefinitelyRescheduled?: boolean | null;
   delayPossible?: boolean | null;
+  indefinitelyRescheduled?: boolean | null;
 };
 
 export type CompetitionMatchPage = {
@@ -746,12 +746,12 @@ export type LeagueMatchDto = {
   team1Description?: string | null;
   team2Description?: string | null;
   results?: VolleyballMatchResultsDto | null;
-  team1Mvp?: MostValuablePlayerDto;
-  team2Mvp?: MostValuablePlayerDto;
+  team1Mvp?: MostValuablePlayerDto | null;
+  team2Mvp?: MostValuablePlayerDto | null;
   matchDayUuid?: string | null;
   leagueUuid?: string | null;
-  indefinitelyRescheduled?: boolean | null;
   delayPossible?: boolean | null;
+  indefinitelyRescheduled?: boolean | null;
 };
 
 export type LeagueMatchPage = {

--- a/codegen/sams/generated/zod.gen.ts
+++ b/codegen/sams/generated/zod.gen.ts
@@ -786,12 +786,12 @@ export const zCompetitionMatchDto = z.object({
   team1Description: z.string().nullish(),
   team2Description: z.string().nullish(),
   results: zVolleyballMatchResultsDto.nullish(),
-  team1Mvp: zMostValuablePlayerDto.optional(),
-  team2Mvp: zMostValuablePlayerDto.optional(),
+  team1Mvp: zMostValuablePlayerDto.nullish(),
+  team2Mvp: zMostValuablePlayerDto.nullish(),
   matchGroupUuid: z.string().nullish(),
   competitionUuid: z.string().nullish(),
-  indefinitelyRescheduled: z.boolean().nullish(),
   delayPossible: z.boolean().nullish(),
+  indefinitelyRescheduled: z.boolean().nullish(),
 });
 
 export const zCompetitionMatchPage = z.object({
@@ -933,12 +933,12 @@ export const zLeagueMatchDto = z.object({
   team1Description: z.string().nullish(),
   team2Description: z.string().nullish(),
   results: zVolleyballMatchResultsDto.nullish(),
-  team1Mvp: zMostValuablePlayerDto.optional(),
-  team2Mvp: zMostValuablePlayerDto.optional(),
+  team1Mvp: zMostValuablePlayerDto.nullish(),
+  team2Mvp: zMostValuablePlayerDto.nullish(),
   matchDayUuid: z.string().nullish(),
   leagueUuid: z.string().nullish(),
-  indefinitelyRescheduled: z.boolean().nullish(),
   delayPossible: z.boolean().nullish(),
+  indefinitelyRescheduled: z.boolean().nullish(),
 });
 
 export const zLeagueMatchPage = z.object({


### PR DESCRIPTION
## Summary
- Accept `null` for `team1Mvp` / `team2Mvp` in the SAMS OpenAPI client patch (same `$ref` nullable pattern as `results` / `referees` / `location`).
- Regenerates Zod/types so unplayed 2026/27 league matches validate instead of being discarded, which left `/termine` empty in prod.

## Test plan
- [ ] Confirm live `getAllLeagueMatches` for VC Müllheim + season 2026/27 returns matches with `team1Mvp: null`
- [ ] After deploy, check https://dev-terijaki-d813f1e8.new.vcmuellheim.de/termine shows upcoming fixtures
- [ ] After merge/prod deploy, confirm https://vcmuellheim.de/termine is no longer empty