### PR TITLE
Keep new Cursor worktrees current with their start branch

### DIFF
--- a/.cursor/setup-worktree-unix.sh
+++ b/.cursor/setup-worktree-unix.sh
@@ -1,16 +1,127 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Shared git dir: fetch once, then sync local main and merge into this worktree's branch.
-git fetch origin main
+log() {
+  echo "[worktree-setup] $*"
+}
 
-root="${ROOT_WORKTREE_PATH:?ROOT_WORKTREE_PATH is not set}"
-if ref="$(git -C "$root" symbolic-ref -q HEAD 2>/dev/null)" && [ "$ref" = "refs/heads/main" ]; then
-  git -C "$root" merge --ff-only origin/main
-else
-  git update-ref refs/heads/main origin/main
-fi
+resolve_default_branch() {
+  local ref
 
-git merge origin/main --no-edit
+  if ref="$(git symbolic-ref -q refs/remotes/origin/HEAD 2>/dev/null)"; then
+    printf '%s\n' "${ref#refs/remotes/origin/}"
+    return 0
+  fi
 
+  if git show-ref --verify --quiet refs/remotes/origin/main; then
+    printf 'main\n'
+    return 0
+  fi
+
+  if git show-ref --verify --quiet refs/remotes/origin/master; then
+    printf 'master\n'
+    return 0
+  fi
+
+  return 1
+}
+
+resolve_base_branch() {
+  local root="${ROOT_WORKTREE_PATH:-}"
+  local branch
+
+  if [ -n "$root" ]; then
+    if branch="$(git -C "$root" symbolic-ref -q --short HEAD 2>/dev/null)"; then
+      printf '%s\n' "$branch"
+      return 0
+    fi
+  fi
+
+  resolve_default_branch
+}
+
+resolve_remote_base() {
+  local base="$1"
+  local default_branch
+
+  if git show-ref --verify --quiet "refs/remotes/origin/${base}"; then
+    printf 'origin/%s\n' "$base"
+    return 0
+  fi
+
+  if default_branch="$(resolve_default_branch)" &&
+    git show-ref --verify --quiet "refs/remotes/origin/${default_branch}"; then
+    printf 'origin/%s\n' "$default_branch"
+    return 0
+  fi
+
+  return 1
+}
+
+refresh_local_base_ref() {
+  local base="$1"
+  local remote="$2"
+  local root="${ROOT_WORKTREE_PATH:-}"
+  local root_branch=""
+
+  if [ -n "$root" ]; then
+    root_branch="$(git -C "$root" symbolic-ref -q --short HEAD 2>/dev/null || true)"
+  fi
+
+  if [ -n "$root_branch" ] && [ "$root_branch" = "$base" ]; then
+    log "fast-forwarding root checkout ${base} to ${remote} (best-effort)..."
+    git -C "$root" merge --ff-only "${remote}" >/dev/null 2>&1 ||
+      log "root checkout could not fast-forward (dirty or diverged); continuing"
+    return 0
+  fi
+
+  if git show-ref --verify --quiet "refs/heads/${base}"; then
+    if git merge-base --is-ancestor "refs/heads/${base}" "${remote}"; then
+      log "updating local ${base} to ${remote} (fast-forward)"
+      git update-ref "refs/heads/${base}" "${remote}"
+    else
+      log "local ${base} is not an ancestor of ${remote}; leaving it unchanged"
+    fi
+    return 0
+  fi
+
+  log "creating local ${base} at ${remote}"
+  git update-ref "refs/heads/${base}" "${remote}"
+}
+
+sync_worktree_with_base() {
+  local base remote behind
+
+  log "fetching from origin..."
+  git fetch origin
+
+  if ! base="$(resolve_base_branch)"; then
+    log "could not resolve a base branch; skipping sync"
+    return 0
+  fi
+
+  if ! remote="$(resolve_remote_base "$base")"; then
+    log "no origin remote for ${base} or the default branch; skipping sync"
+    return 0
+  fi
+
+  log "base branch is ${base} (${remote})"
+  refresh_local_base_ref "$base" "$remote"
+
+  behind="$(git rev-list --count "HEAD..${remote}" 2>/dev/null || true)"
+  behind="${behind:-0}"
+  if [ "${behind}" -gt 0 ]; then
+    log "worktree is ${behind} commit(s) behind ${remote}, merging..."
+    if ! git merge --ff-only "${remote}"; then
+      git merge "${remote}" --no-edit -m "Merge ${remote} into worktree branch"
+    fi
+  else
+    log "worktree is up to date with ${remote}"
+  fi
+}
+
+log "starting worktree setup"
+sync_worktree_with_base
+log "installing dependencies..."
 vp install
+log "done"

--- a/.cursor/worktrees.json
+++ b/.cursor/worktrees.json
@@ -1,9 +1,3 @@
 {
-  "setup-worktree-unix": "setup-worktree-unix.sh",
-  "setup-worktree": [
-    "git fetch origin main",
-    "git update-ref refs/heads/main origin/main",
-    "git merge origin/main --no-edit",
-    "vp install"
-  ]
+  "setup-worktree-unix": "setup-worktree-unix.sh"
 }


### PR DESCRIPTION
## Summary
- Update Cursor worktree setup so a new checkout fetches origin and fast-forwards (or merges) onto the branch Cursor started from, not always `main`.
- Drop the duplicate inline `setup-worktree` command array so Unix only runs the setup script, then keep running `vp install`.

## Test plan
- [ ] Create a worktree with `/worktree` from a stale local `main` and confirm Output → Worktrees Setup fetches and fast-forwards onto `origin/main`.
- [ ] Confirm `vp install` still runs after the git sync, and that setup commands are not run twice.
- [ ] Confirm a worktree started from a non-main branch catches up with that branch’s origin remote instead of always merging `main`.